### PR TITLE
Move tile array/map ops lowering logic outside JAX bindings.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,14 +50,35 @@ filterwarnings = [
 testpaths = ["tests"]
 markers = ["ipu_hardware"]
 
-
 [tool.cibuildwheel]
 test-command = "pytest {project}/tests"
 test-extras = ["test"]
 test-skip = ["*universal2:arm64"]
 build-verbosity = 1
 
-
 [tool.black]
 line-length = 120
 target-version = ['py38', 'py39', 'py310']
+
+[tool.isort]
+line_length = 120
+known_first_party = "tessellate_ipu"
+
+[tool.mypy]
+python_version = "3.8"
+plugins = ["numpy.typing.mypy_plugin"]
+# Config heavily inspired by Pydantic!
+show_error_codes = true
+# strict_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_unused_configs = true
+check_untyped_defs = true
+disallow_any_generics = true
+no_implicit_optional = false
+# disallow_incomplete_defs = true
+# disallow_untyped_decorators = true
+# disallow_untyped_calls = true
+# # disallow_subclassing_any = true
+# # for strict mypy: (this is the tricky one :-))
+# disallow_untyped_defs = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,30 +9,3 @@ per-file-ignores =
     tessellate_ipu/lax/__init__.py: F401
     tessellate_ipu/linalg/__init__.py: F401
     tessellate_ipu/utils/__init__.py: F401
-
-[isort]
-line_length = 120
-known_first_party = tessellate_ipu
-# multi_line_output = 3
-# include_trailing_comma = True
-# force_grid_wrap = 0
-# combine_as_imports = True
-
-[mypy]
-plugins = numpy.typing.mypy_plugin
-# Config heavily inspired by Pydantic!
-python_version = 3.8
-show_error_codes = True
-# strict_optional = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-warn_unused_configs = True
-check_untyped_defs = True
-disallow_any_generics = True
-no_implicit_optional = False
-# disallow_incomplete_defs = True
-# disallow_untyped_decorators = True
-# disallow_untyped_calls = True
-# # disallow_subclassing_any = True
-# # for strict mypy: (this is the tricky one :-))
-# disallow_untyped_defs = True

--- a/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
+++ b/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
@@ -1,8 +1,4 @@
 // Copyright (c) 2022 Graphcore Ltd. All rights reserved.
-#define FMT_HEADER_ONLY
-#include <fmt/format.h>
-#include <fmt/ranges.h>
-
 #include "base_types.hpp"
 #include "ipu_custom_primitive.hpp"
 #include "tile_array_ops.hpp"
@@ -43,31 +39,11 @@ class TilePutShardedPrimitive : public TilePutBase {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debugContext = poplar::DebugContext(debug_prefix);
-    if (inputs.size() != 1) {
-      throw poputil::poplibs_error(
-          "IPU tile put sharded expecting a single input tensor.");
-    }
-    static_assert(sizeof(TileIndexType) == 4);
-    auto input = inputs[0];
-
+    const auto debug_context = poplar::DebugContext(debug_prefix);
     // Passing the tile array as attributes.
     const auto tile_array = extractTileArray(attributes);
-    if (input.shape()[0] != tile_array.size()) {
-      throw poputil::poplibs_error(
-          fmt::format("IPU tile put sharding: inconsistent input size {} and "
-                      "tiles length {}.",
-                      input.shape()[0], tile_array.size()));
-    }
-
-    // Create output tensor, with proper tile mapping.
-    // TODO: link to Slack discussion on VarRegion contiguity.
-    auto output = createShardedVariable(graph, input.elementType(),
-                                        input[0].shape(), tile_array);
-    // Copy data tensor into the output.
-    auto prog = poplar::program::Copy(input, output);
-    outputs.push_back(output);
-    return prog;
+    return lowerTilePutShardedToPoplar(graph, inputs, outputs, tile_array,
+                                       debug_context);
   }
 };
 
@@ -91,23 +67,10 @@ class TilePutReplicatedPrimitive : public TilePutBase {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debugContext = poplar::DebugContext(debug_prefix);
-    if (inputs.size() != 1) {
-      throw poputil::poplibs_error(
-          "IPU tile put replicated expecting a single input tensor.");
-    }
-    static_assert(sizeof(TileIndexType) == 4);
-    auto input = inputs[0];
-
+    const auto debug_context = poplar::DebugContext(debug_prefix);
     const auto tile_array = extractTileArray(attributes);
-    // Create output tensor, with proper tile mapping.
-    auto input_broadcasted = input.expand({0}).broadcast(tile_array.size(), 0);
-    auto output = createShardedVariable(graph, input.elementType(),
-                                        input.shape(), tile_array);
-    // Copy data tensor into the output.
-    auto prog = poplar::program::Copy(input_broadcasted, output, false);
-    outputs.push_back(output);
-    return prog;
+    return lowerTilePutReplicatedToPoplar(graph, inputs, outputs, tile_array,
+                                          debug_context);
   }
 };
 
@@ -131,40 +94,10 @@ class TileGatherPrimitive : public jax::ipu::PrimitiveInterface {
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
     const auto debug_context = poplar::DebugContext(debug_prefix);
-    if (inputs.size() != 1) {
-      throw poputil::poplibs_error(
-          "IPU tile gather expecting a single input tensor.");
-    }
-    const auto& input = inputs[0];
-    const auto item_shape = input[0].shape();
-    const auto item_type = input.elementType();
-
     // Tile gather parameters.
     const auto params = ipu::from_json_str<TileGatherParams>(attributes);
-    // Create the output tensor per gather index, then concat.
-    auto seq = poplar::program::Sequence();
-    std::vector<poplar::Tensor> output_slices;
-    for (std::size_t idx = 0; idx < params.tiles.size(); ++idx) {
-      const auto gather_idx = params.indices[idx];
-      // Get the proper item at the gather index.
-      const auto input_item = input[gather_idx];
-      const auto input_tile = params.previous_tiles[gather_idx];
-      const auto output_tile = params.tiles[idx];
-      if (input_tile == output_tile) {
-        // No copy => using directly the existing data on the tile.
-        output_slices.push_back(input_item.expand({0}));
-      } else {
-        // New Poplar tensor + copy to the proper tile.
-        auto output_item =
-            graph.addVariable(item_type, item_shape, debug_context);
-        graph.setTileMapping(output_item, output_tile);
-        seq.add(poplar::program::Copy(input_item, output_item));
-        output_slices.push_back(output_item.expand({0}));
-      }
-    }
-    auto output = poplar::concat(output_slices);
-    outputs.push_back(output);
-    return seq;
+    return lowerTileGatherToPoplar(graph, inputs, outputs, params,
+                                   debug_context);
   }
 };
 
@@ -190,49 +123,10 @@ class TileDataBarrierPrimitive : public jax::ipu::PrimitiveInterface {
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
     const auto debug_context = poplar::DebugContext(debug_prefix);
-    if (inputs.size() < 1) {
-      throw poputil::poplibs_error(
-          "IPU tile data barrier expecting multiple input tensors.");
-    }
-    // Half precision different on IPU model.
-    const auto& target = graph.getTarget();
-    const bool is_half_accurate =
-        (target.getTargetType() == poplar::TargetType::IPU);
     // Tile barrier parameters (with tile sharding).
     const auto params = ipu::from_json_str<TileDataBarrierParams>(attributes);
-
-    // Association of barrier tensors per tile.
-    std::vector<std::vector<poplar::Tensor>> tensors_per_tiles(params.max_tile +
-                                                               1);
-    for (size_t idx = 0; idx < inputs.size(); ++idx) {
-      // Reinterpret input tensor to a reference type.
-      const auto& in_reinterpret =
-          tileBarrierReinterpretTensor(inputs[idx], is_half_accurate);
-      const auto& tiles = params.inputs_tiles[idx];
-      for (size_t k = 0; k < tiles.size(); ++k) {
-        // Flatten the tensor on every tile to 1D.
-        tensors_per_tiles[tiles[k]].push_back(in_reinterpret[k].flatten());
-      }
-    }
-
-    auto prog = poplar::program::Sequence();
-    poplar::ComputeSet cs = graph.addComputeSet(debug_context);
-    for (TileIndexType tile = 0; tile < TileIndexType(tensors_per_tiles.size());
-         ++tile) {
-      const auto& tensors = tensors_per_tiles[tile];
-      if (tensors.size() == 0) {
-        continue;
-      }
-      // Add barrier vertex on the tile.
-      auto v = graph.addVertex(cs, params.vname);
-      graph.setTileMapping(v, tile);
-      graph.setPerfEstimate(v, 14);
-      // Map collection of tensors to vertex IO.
-      graph.connect(v["data"], tensors);
-    }
-    prog.add(poplar::program::Execute(cs, debug_context));
-    outputs = inputs;
-    return prog;
+    return lowerTileDataBarrierToPoplar(graph, inputs, outputs, params,
+                                        debug_context);
   }
 };
 
@@ -257,14 +151,8 @@ class TileConstantReplicatedPrimitive : public jax::ipu::PrimitiveInterface {
       const std::string& debug_prefix) {
     const auto debug_context = poplar::DebugContext(debug_prefix);
     const auto params = ipu::from_json_str<TileConstantParams>(attributes);
-    const std::string raw_values = params.data.decode();
-    const auto raw_values_ref =
-        poplar::ArrayRef<char>(raw_values.data(), raw_values.size());
-    auto t = createReplicatedConstantTensor(graph, params.aval.dtype,
-                                            params.aval.shape, raw_values_ref,
-                                            params.tiles, debug_context);
-    outputs.push_back(t);
-    return poplar::program::Sequence();
+    return lowerTileConstantReplicatedToPoplar(graph, inputs, outputs, params,
+                                               debug_context);
   }
 };
 
@@ -289,14 +177,8 @@ class TileConstantShardedPrimitive : public jax::ipu::PrimitiveInterface {
       const std::string& debug_prefix) {
     const auto debug_context = poplar::DebugContext(debug_prefix);
     const auto params = ipu::from_json_str<TileConstantParams>(attributes);
-    const std::string raw_values = params.data.decode();
-    const auto raw_values_ref =
-        poplar::ArrayRef<char>(raw_values.data(), raw_values.size());
-    auto t = createShardedConstantTensor(graph, params.aval.dtype,
-                                         params.aval.shape, raw_values_ref,
-                                         params.tiles, debug_context);
-    outputs.push_back(t);
-    return poplar::program::Sequence();
+    return lowerTileConstantShardedToPoplar(graph, inputs, outputs, params,
+                                            debug_context);
   }
 };
 
@@ -329,17 +211,10 @@ class TileMapEquationCall : public jax::ipu::PrimitiveInterface {
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
     const auto debug_context = poplar::DebugContext(debug_prefix);
-    // Deserialize tile mapped equation, and add to the graph.
     const auto tile_equation =
         ipu::from_json_str<ipu::TileMapEquation>(attributes);
-    auto prog = poplar::program::Sequence();
-    // IPU tiles synchronization before compute set.
-    if (tile_equation.sync) {
-      const auto sync_type = poplar::SyncType::INTERNAL;
-      prog.add(poplar::program::Sync(sync_type, debug_context));
-    }
-    outputs = tile_equation.add(graph, prog, inputs, debug_context);
-    return prog;
+    return lowerTileMapCallToPoplar(graph, inputs, outputs, tile_equation,
+                                    debug_context);
   }
 };
 

--- a/tessellate_ipu/lib/tile_array_ops.cpp
+++ b/tessellate_ipu/lib/tile_array_ops.cpp
@@ -1,5 +1,14 @@
 // Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+#define FMT_HEADER_ONLY
 #include "tile_array_ops.hpp"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
+#include <poplar/Program.hpp>
+#include <poputil/exceptions.hpp>
+
+#include "tile_array_utils.hpp"
 
 namespace ipu {
 
@@ -38,6 +47,168 @@ poplar::Tensor tileBarrierReinterpretTensor(const poplar::Tensor& t,
   }
   // Can handle tensor :/
   throw std::runtime_error("Unknown Poplar tensor type in tile data barrier.");
+}
+
+poplar::program::Program lowerTilePutShardedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileArrayType& tile_array,
+    const poplar::DebugContext& debug_context) {
+  if (inputs.size() != 1) {
+    throw poputil::poplibs_error(
+        "IPU tile put sharded expecting a single input tensor.");
+  }
+  static_assert(sizeof(TileIndexType) == 4);
+  auto input = inputs[0];
+
+  if (input.shape()[0] != tile_array.size()) {
+    throw poputil::poplibs_error(
+        fmt::format("IPU tile put sharding: inconsistent input size {} and "
+                    "tiles length {}.",
+                    input.shape()[0], tile_array.size()));
+  }
+
+  // Create output tensor, with proper tile mapping.
+  // TODO: link to Slack discussion on VarRegion contiguity.
+  auto output = createShardedVariable(graph, input.elementType(),
+                                      input[0].shape(), tile_array);
+  // Copy data tensor into the output.
+  auto prog = poplar::program::Copy(input, output);
+  outputs.push_back(output);
+  return prog;
+}
+
+poplar::program::Program lowerTilePutReplicatedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileArrayType& tile_array,
+    const poplar::DebugContext& debug_context) {
+  if (inputs.size() != 1) {
+    throw poputil::poplibs_error(
+        "IPU tile put replicated expecting a single input tensor.");
+  }
+  static_assert(sizeof(TileIndexType) == 4);
+  auto input = inputs[0];
+
+  // Create output tensor, with proper tile mapping.
+  auto input_broadcasted = input.expand({0}).broadcast(tile_array.size(), 0);
+  auto output = createShardedVariable(graph, input.elementType(), input.shape(),
+                                      tile_array);
+  // Copy data tensor into the output.
+  auto prog = poplar::program::Copy(input_broadcasted, output, false);
+  outputs.push_back(output);
+  return prog;
+}
+
+poplar::program::Program lowerTileGatherToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileGatherParams& params,
+    const poplar::DebugContext& debug_context) {
+  if (inputs.size() != 1) {
+    throw poputil::poplibs_error(
+        "IPU tile gather expecting a single input tensor.");
+  }
+  const auto& input = inputs[0];
+  const auto item_shape = input[0].shape();
+  const auto item_type = input.elementType();
+
+  // Create the output tensor per gather index, then concat.
+  auto seq = poplar::program::Sequence();
+  std::vector<poplar::Tensor> output_slices;
+  for (std::size_t idx = 0; idx < params.tiles.size(); ++idx) {
+    const auto gather_idx = params.indices[idx];
+    // Get the proper item at the gather index.
+    const auto input_item = input[gather_idx];
+    const auto input_tile = params.previous_tiles[gather_idx];
+    const auto output_tile = params.tiles[idx];
+    if (input_tile == output_tile) {
+      // No copy => using directly the existing data on the tile.
+      output_slices.push_back(input_item.expand({0}));
+    } else {
+      // New Poplar tensor + copy to the proper tile.
+      auto output_item =
+          graph.addVariable(item_type, item_shape, debug_context);
+      graph.setTileMapping(output_item, output_tile);
+      seq.add(poplar::program::Copy(input_item, output_item));
+      output_slices.push_back(output_item.expand({0}));
+    }
+  }
+  auto output = poplar::concat(output_slices);
+  outputs.push_back(output);
+  return seq;
+}
+
+poplar::program::Program lowerTileDataBarrierToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileDataBarrierParams& params,
+    const poplar::DebugContext& debug_context) {
+  if (inputs.size() < 1) {
+    throw poputil::poplibs_error(
+        "IPU tile data barrier expecting multiple input tensors.");
+  }
+  // Half precision different on IPU model.
+  const auto& target = graph.getTarget();
+  const bool is_half_accurate =
+      (target.getTargetType() == poplar::TargetType::IPU);
+
+  // Association of barrier tensors per tile.
+  std::vector<std::vector<poplar::Tensor>> tensors_per_tiles(params.max_tile +
+                                                             1);
+  for (size_t idx = 0; idx < inputs.size(); ++idx) {
+    // Reinterpret input tensor to a reference type.
+    const auto& in_reinterpret =
+        tileBarrierReinterpretTensor(inputs[idx], is_half_accurate);
+    const auto& tiles = params.inputs_tiles[idx];
+    for (size_t k = 0; k < tiles.size(); ++k) {
+      // Flatten the tensor on every tile to 1D.
+      tensors_per_tiles[tiles[k]].push_back(in_reinterpret[k].flatten());
+    }
+  }
+
+  auto prog = poplar::program::Sequence();
+  poplar::ComputeSet cs = graph.addComputeSet(debug_context);
+  for (TileIndexType tile = 0; tile < TileIndexType(tensors_per_tiles.size());
+       ++tile) {
+    const auto& tensors = tensors_per_tiles[tile];
+    if (tensors.size() == 0) {
+      continue;
+    }
+    // Add barrier vertex on the tile.
+    auto v = graph.addVertex(cs, params.vname);
+    graph.setTileMapping(v, tile);
+    graph.setPerfEstimate(v, 14);
+    // Map collection of tensors to vertex IO.
+    graph.connect(v["data"], tensors);
+  }
+  prog.add(poplar::program::Execute(cs, debug_context));
+  outputs = inputs;
+  return prog;
+}
+
+poplar::program::Program lowerTileConstantShardedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileConstantParams& params,
+    const poplar::DebugContext& debug_context) {
+  const std::string raw_values = params.data.decode();
+  const auto raw_values_ref =
+      poplar::ArrayRef<char>(raw_values.data(), raw_values.size());
+  auto t =
+      createShardedConstantTensor(graph, params.aval.dtype, params.aval.shape,
+                                  raw_values_ref, params.tiles, debug_context);
+  outputs.push_back(t);
+  return poplar::program::Sequence();
+}
+
+poplar::program::Program lowerTileConstantReplicatedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileConstantParams& params,
+    const poplar::DebugContext& debug_context) {
+  const std::string raw_values = params.data.decode();
+  const auto raw_values_ref =
+      poplar::ArrayRef<char>(raw_values.data(), raw_values.size());
+  auto t = createReplicatedConstantTensor(graph, params.aval.dtype,
+                                          params.aval.shape, raw_values_ref,
+                                          params.tiles, debug_context);
+  outputs.push_back(t);
+  return poplar::program::Sequence();
 }
 
 }  // namespace ipu

--- a/tessellate_ipu/lib/tile_array_ops.hpp
+++ b/tessellate_ipu/lib/tile_array_ops.hpp
@@ -1,9 +1,9 @@
 // Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 #pragma once
 #include <json/json.hpp>
+#include <poplar/Graph.hpp>
 
 #include "base_types.hpp"
-#include "tile_array_utils.hpp"
 
 namespace ipu {
 /**
@@ -55,5 +55,48 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TileConstantParams, aval, tiles, data)
  */
 poplar::Tensor tileBarrierReinterpretTensor(const poplar::Tensor& t,
                                             bool is_half_accurate);
+
+/**
+ * @brief Lower `tile_put_sharded` to a Poplar program.
+ */
+poplar::program::Program lowerTilePutShardedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileArrayType& tile_array,
+    const poplar::DebugContext& debug_context);
+/**
+ * @brief Lower `tile_put_replicated` to a Poplar program.
+ */
+poplar::program::Program lowerTilePutReplicatedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileArrayType& tile_array,
+    const poplar::DebugContext& debug_context);
+/**
+ * @brief Lower `tile_gather` to a Poplar program.
+ */
+poplar::program::Program lowerTileGatherToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileGatherParams& params,
+    const poplar::DebugContext& debug_context);
+/**
+ * @brief Lower `tile_data_barrier` to a Poplar program.
+ */
+poplar::program::Program lowerTileDataBarrierToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileDataBarrierParams& params,
+    const poplar::DebugContext& debug_context);
+/**
+ * @brief Lower `tile_constant_sharded` to a Poplar program.
+ */
+poplar::program::Program lowerTileConstantShardedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileConstantParams& params,
+    const poplar::DebugContext& debug_context);
+/**
+ * @brief Lower `tile_constant_replicated` to a Poplar program.
+ */
+poplar::program::Program lowerTileConstantReplicatedToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileConstantParams& params,
+    const poplar::DebugContext& debug_context);
 
 }  // namespace ipu

--- a/tessellate_ipu/lib/tile_map_ops.cpp
+++ b/tessellate_ipu/lib/tile_map_ops.cpp
@@ -131,4 +131,19 @@ std::vector<poplar::Tensor> TileMapEquation::add(
   this->add(graph, prog, inputs_all, outputs, debug_prefix);
   return outputs;
 }
+
+poplar::program::Program lowerTileMapCallToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileMapEquation& tile_map_eqn,
+    const poplar::DebugContext& debug_context) {
+  auto prog = poplar::program::Sequence();
+  // IPU tiles synchronization before compute set.
+  if (tile_map_eqn.sync) {
+    const auto sync_type = poplar::SyncType::INTERNAL;
+    prog.add(poplar::program::Sync(sync_type, debug_context));
+  }
+  outputs = tile_map_eqn.add(graph, prog, inputs, debug_context);
+  return prog;
+}
+
 }  // namespace ipu

--- a/tessellate_ipu/lib/tile_map_ops.hpp
+++ b/tessellate_ipu/lib/tile_map_ops.hpp
@@ -260,4 +260,18 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TileMapEquation, pname, vname, tiles,
                                    tmp_space_aval, gp_filename, perf_estimate,
                                    sync)
 
+/**
+ * @brief Lower `tile_map` call to Poplar.
+ * @param graph Poplar graph to update.
+ * @param inputs List of inputs.
+ * @param outputs List of outputs, to update.
+ * @param tile_map_eqn TileMapEquation info.
+ * @param debug_context Poplar debug context.
+ * @return Poplar program.
+ */
+poplar::program::Program lowerTileMapCallToPoplar(
+    poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+    std::vector<poplar::Tensor>& outputs, const TileMapEquation& tile_map_eqn,
+    const poplar::DebugContext& debug_context);
+
 }  // namespace ipu


### PR DESCRIPTION
This PR is moving the Poplar lowering logic into proper functions, in order to make the JAX/XLA custom ops layer as thin as possible.

It should allow us to support additional backends (e.g. Poptorch) in the near future.