### PR TITLE
Port TessellateIPU to Nanobind Python bindings library

### DIFF
--- a/.github/workflows/notebook-tests-public.yaml
+++ b/.github/workflows/notebook-tests-public.yaml
@@ -31,7 +31,7 @@ jobs:
         id: pip-cache
         run: |
           python3 -m pip install --upgrade pip wheel setuptools jupyter
-          python3 -m pip install --upgrade build cmake ninja pybind11 scikit_build_core[pyproject]
+          python3 -m pip install --upgrade build cmake nanobind ninja pip scikit_build_core[pyproject]
       # Install JAX for IPU.
       - name: Install JAX for IPU
         run: |

--- a/.github/workflows/tests-internal.yaml
+++ b/.github/workflows/tests-internal.yaml
@@ -47,8 +47,7 @@ jobs:
       - name: Update pip
         id: pip-cache
         run: |
-          python3 -m pip install --upgrade pip wheel setuptools
-          python3 -m pip install --upgrade build cmake ninja pybind11 scikit_build_core[pyproject]
+          python3 -m pip install --upgrade build cmake nanobind ninja pip scikit_build_core[pyproject]
       # Install JAX for IPU.
       - name: Install JAX for IPU
         run: |
@@ -97,8 +96,7 @@ jobs:
       - name: Instal Python base dependencies
         id: pip-cache
         run: |
-          python3 -m pip install --upgrade pip wheel setuptools docker
-          python3 -m pip install --upgrade build cmake ninja pybind11 scikit_build_core[pyproject]
+          python3 -m pip install --upgrade build cmake docker nanobind ninja pip scikit_build_core[pyproject]
       # Necessary for attaching IPU hardware.
       - name: Attach RDMA Network
         run: |

--- a/.github/workflows/tests-public.yaml
+++ b/.github/workflows/tests-public.yaml
@@ -47,8 +47,7 @@ jobs:
       - name: Update pip
         id: pip-cache
         run: |
-          python3 -m pip install --upgrade pip wheel setuptools
-          python3 -m pip install --upgrade build cmake ninja pybind11 scikit_build_core[pyproject]
+          python3 -m pip install --upgrade build cmake nanobind ninja pip scikit_build_core[pyproject]
       # Install JAX for IPU.
       - name: Install JAX for IPU
         run: |
@@ -61,7 +60,7 @@ jobs:
       # Build & install sdist package.
       - name: Install TessellateIPU
         run: |
-          python3 -m build --no-isolation
+          python3 -m build --no-isolation --sdist
           pip3 install dist/*.tar.gz
       # Run repository unit tests.
       - name: Run TessellateIPU unit tests (model)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT SKBUILD)
   in your environment once and use the following command that avoids
   a costly creation of a new virtual environment at every compilation:
   =====================================================================
-   $ pip install pybind11 scikit-build-core[pyproject] ninja
+   $ pip install nanobind scikit-build-core[pyproject] ninja
    $ pip install --no-build-isolation -ve .
   =====================================================================
   You may optionally add -Ceditable.rebuild=true to auto-rebuild when
@@ -32,8 +32,12 @@ endif()
 
 message(==>PROJECT_NAME="${SKBUILD_PROJECT_NAME}")
 
-find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
-find_package(pybind11 CONFIG REQUIRED)
+# Python components needed by nanobind
+find_package(
+  Python 3.8 REQUIRED
+  COMPONENTS Interpreter Development.Module
+  OPTIONAL_COMPONENTS Development.SABIModule)
+find_package(nanobind CONFIG REQUIRED)
 
 # Common TessellateIPU static library.
 add_library(
@@ -56,16 +60,32 @@ target_compile_definitions(${SKBUILD_PROJECT_NAME}_core
 target_compile_features(${SKBUILD_PROJECT_NAME}_core PUBLIC cxx_std_17)
 
 # Common TessellateIPU library Python bindings.
-python_add_library(py${SKBUILD_PROJECT_NAME}_core MODULE
-                   tessellate_ipu/lib/tessellate_ipu_core.cpp WITH_SOABI)
+nanobind_add_module(
+  py${SKBUILD_PROJECT_NAME}_core
+  # Target the stable ABI for Python 3.12+, which reduces the number of binary
+  # wheels that must be built. This does nothing on older Python versions
+  STABLE_ABI
+  # Build libnanobind statically and merge it into the extension (which itself
+  # remains a shared library)
+  NB_STATIC
+  # Common TessellateIPU library Python bindings.
+  tessellate_ipu/lib/tessellate_ipu_core.cpp)
 target_link_libraries(py${SKBUILD_PROJECT_NAME}_core
-                      PRIVATE pybind11::headers ${SKBUILD_PROJECT_NAME}_core)
+                      PRIVATE ${SKBUILD_PROJECT_NAME}_core)
 
 # TessellateIPU library JAX ops bindings.
-python_add_library(py${SKBUILD_PROJECT_NAME}_ops_jax MODULE
-                   tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp WITH_SOABI)
+nanobind_add_module(
+  py${SKBUILD_PROJECT_NAME}_ops_jax
+  # Target the stable ABI for Python 3.12+, which reduces the number of binary
+  # wheels that must be built. This does nothing on older Python versions
+  STABLE_ABI
+  # Build libnanobind statically and merge it into the extension (which itself
+  # remains a shared library)
+  NB_STATIC
+  # TessellateIPU library JAX ops bindings.
+  tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp)
 target_link_libraries(py${SKBUILD_PROJECT_NAME}_ops_jax
-                      PRIVATE pybind11::headers ${SKBUILD_PROJECT_NAME}_core)
+                      PRIVATE ${SKBUILD_PROJECT_NAME}_core)
 
 # TODO: TessellateIPU library Poptorch ops bindings.
 

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ TessellateIPU is implemented using C++ custom operations. These have the followi
 | [fmt](https://github.com/fmtlib/fmt) | A modern C++ formatting library | [MIT license](https://github.com/fmtlib/fmt/blob/master/LICENSE.rst) |
 | [half](https://sourceforge.net/projects/half/) | IEEE-754 conformant half-precision library | MIT license |
 | [json](https://github.com/nlohmann/json) | JSON for modern C++ | [MIT license](https://github.com/nlohmann/json/blob/develop/LICENSE.MIT) |
-| [pybind11](https://github.com/pybind/pybind11) | C++11 python bindings | [BSD License 2.0](https://github.com/pybind/pybind11/blob/master/LICENSE) |
+| [nanobind](https://github.com/wjakob/nanobind) | Tiny C++/Python bindings | [BSD 3-Clause License](https://github.com/wjakob/nanobind/blob/master/LICENSE) |

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,7 @@ There are some guidelines for doing development on the TessellateIPU library.
 
 For local development, we recommend using a pip editable install:
 ```bash
-pip install cmake ninja pybind11 scikit-build-core[pyproject]
+pip install cmake ninja nanobind scikit-build-core[pyproject]
 pip install --no-build-isolation -ve .
 ```
 The first line will install the required build dependencies, and the second will create an editable install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["ninja", "scikit-build-core>=0.3.3", "pybind11"]
+requires = ["ninja", "scikit-build-core>=0.4.3", "nanobind>=1.3.2"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/tessellate_ipu/core/tile_array_primitives.py
+++ b/tessellate_ipu/core/tile_array_primitives.py
@@ -13,25 +13,7 @@ from jax.interpreters import mlir
 from jax.interpreters.mlir import LoweringRuleContext, ir, mhlo
 from jax.ipu.primitive import ipu_mlir_lowering_custom_primitive
 
-from tessellate_ipu.lib.pytessellate_ipu_core import (  # noqa: E402, F401
-    Base64Data,
-    IpuShapedArray,
-    IpuType,
-    TileConstantParams,
-    TileDataBarrierParams,
-    TileGatherParams,
-)
-from tessellate_ipu.lib.pytessellate_ipu_ops_jax import (  # noqa: E402, F401
-    TileConstantReplicatedPrimitive,
-    TileConstantShardedPrimitive,
-    TileDataBarrierPrimitive,
-    TileGatherPrimitive,
-    TilePutReplicatedPrimitive,
-    TilePutShardedPrimitive,
-)
 from tessellate_ipu.utils import DTypeLike, NDArray
-
-from .tile_common_utils import make_ipu_shaped_array
 
 tile_put_sharded_prim_p = core.Primitive("tile_put_sharded")
 tile_put_replicated_prim_p = core.Primitive("tile_put_replicated")
@@ -71,6 +53,8 @@ def tile_put_sharded_prim_mlir_lowering_default(ctx, xc, tiles):
 
 def tile_put_sharded_prim_mlir_lowering_ipu(ctx: LoweringRuleContext, xc: ir.Value, tiles: Any) -> Sequence[ir.Value]:
     """`tile_put_sharded_prim` IPU backend MLIR lowering, as a custom primitive."""
+    from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TilePutShardedPrimitive
+
     inputs = [xc]
     # Passing the tiles collections as a raw attributes to the C++ implementation.
     raw_attributes = make_tiles_raw_attributes(tiles)
@@ -123,6 +107,8 @@ def tile_put_replicated_prim_mlir_lowering_ipu(
     ctx: LoweringRuleContext, xc: ir.Value, tiles: Any
 ) -> Sequence[ir.Value]:
     """`tile_put_replicated_prim` IPU backend MLIR lowering, as a custom primitive."""
+    from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TilePutReplicatedPrimitive
+
     inputs = [xc]
     # Passing the tiles collections as a raw attributes to the C++ implementation.
     raw_attributes = make_tiles_raw_attributes(tiles)
@@ -168,6 +154,10 @@ def tile_gather_prim_mlir_lowering_ipu(
     ctx: LoweringRuleContext, xc: ir.Value, previous_tiles: Any, indices: Any, tiles: Any
 ) -> Sequence[ir.Value]:
     """`tile_gather_prim` IPU backend MLIR lowering, as a custom primitive."""
+    # FIXME: Local imports to deal with JAX/typing(?) leaked references.
+    from tessellate_ipu.lib.pytessellate_ipu_core import TileGatherParams
+    from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TileGatherPrimitive
+
     inputs = [xc]
     # Til gather parameters, to pass to the XLA/HLO op.
     gather_params = TileGatherParams(previous_tiles, indices, tiles)
@@ -228,6 +218,10 @@ def tile_data_barrier_prim_mlir_lowering_ipu(
     ctx: LoweringRuleContext, *args: ir.Value, **params: Any
 ) -> Sequence[ir.Value]:
     """`tile_data_barrier_prim` IPU backend MLIR lowering, as a custom primitive."""
+    # FIXME: Local imports to deal with JAX/typing(?) leaked references.
+    from tessellate_ipu.lib.pytessellate_ipu_core import TileDataBarrierParams
+    from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TileDataBarrierPrimitive
+
     from .tile_interpreter_primitives import make_ipu_vertex_name_templated
 
     inputs = list(args)
@@ -303,6 +297,12 @@ def tile_constant_replicated_prim_mlir_lowering_ipu(
     ctx: LoweringRuleContext, dummy: ir.Value, data: NDArray[Any], tiles: Any
 ) -> Sequence[ir.Value]:
     """`tile_constant_replicated_prim` IPU backend MLIR lowering, as a custom primitive."""
+    # FIXME: Local imports to deal with JAX/typing(?) leaked references.
+    from tessellate_ipu.lib.pytessellate_ipu_core import Base64Data, TileConstantParams
+    from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TileConstantReplicatedPrimitive
+
+    from .tile_common_utils import make_ipu_shaped_array
+
     params = TileConstantParams(
         aval=make_ipu_shaped_array(data.shape, data.dtype),
         tiles=tiles,
@@ -353,6 +353,12 @@ def tile_constant_sharded_prim_mlir_lowering_ipu(
     ctx: LoweringRuleContext, dummy: ir.Value, data: NDArray[Any], tiles: Any
 ) -> Sequence[ir.Value]:
     """`tile_constant_sharded_prim` IPU backend MLIR lowering, as a custom primitive."""
+    # FIXME: Local imports to deal with JAX/typing(?) leaked references.
+    from tessellate_ipu.lib.pytessellate_ipu_core import Base64Data, TileConstantParams
+    from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TileConstantShardedPrimitive
+
+    from .tile_common_utils import make_ipu_shaped_array
+
     params = TileConstantParams(
         aval=make_ipu_shaped_array(data.shape, data.dtype),
         tiles=tiles,

--- a/tessellate_ipu/core/tile_interpreter_primitives.py
+++ b/tessellate_ipu/core/tile_interpreter_primitives.py
@@ -13,21 +13,21 @@ from jax.interpreters.batching import primitive_batchers
 from jax.interpreters.mlir import LoweringRuleContext, ir
 from jax.ipu.primitive import ipu_mlir_lowering_custom_primitive
 
-from tessellate_ipu.utils import NDArray
-
-from .tile_array_primitives import Base64Data, IpuType
-from .tile_common_utils import from_numpy_dtype_to_ipu_type, get_ipu_type_name
-
-Array = Any
-
 from tessellate_ipu.lib.pytessellate_ipu_core import (  # noqa: E402
+    Base64Data,
     IpuTileMapEquation,
+    IpuType,
     IpuVertexAttributeF32,
     IpuVertexAttributeI32,
     IpuVertexIOInfo,
     IpuVertexIOType,
 )
 from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TileMapEquationCall  # noqa: E402
+from tessellate_ipu.utils import NDArray
+
+from .tile_common_utils import from_numpy_dtype_to_ipu_type, get_ipu_type_name
+
+Array = Any
 
 
 def primitive_has_impl(p: core.Primitive) -> bool:
@@ -74,7 +74,8 @@ def make_ipu_vertex_io_info(
         IPU vertex IO info.
     """
     ipu_type = from_numpy_dtype_to_ipu_type(aval.dtype)
-    return IpuVertexIOInfo(name=name, iotype=iotype, shape=aval.shape, dtype=ipu_type, vertex_dim2=int(vertex_dim2))
+    vinfo = IpuVertexIOInfo(name=name, iotype=iotype, shape=aval.shape, dtype=ipu_type, vertex_dim2=int(vertex_dim2))
+    return vinfo
 
 
 def make_ipu_vertex_constant_info(name: str, data: NDArray[Any], vertex_dim2: int = 0) -> IpuVertexIOInfo:

--- a/tessellate_ipu/lib/base_types.hpp
+++ b/tessellate_ipu/lib/base_types.hpp
@@ -165,6 +165,19 @@ struct Base64Data {
   /** Raw data as base64 encoded. */
   std::string encoded_data;
 
+  // Default constructors/operator=
+  Base64Data() = default;
+  Base64Data(Base64Data&&) noexcept = default;
+  Base64Data(const Base64Data&) = default;
+  Base64Data& operator=(Base64Data&&) noexcept = default;
+  Base64Data& operator=(const Base64Data&) = default;
+
+  /** Constructors from base64 encoded data. */
+  Base64Data(std::string _encoded_data) noexcept
+      : encoded_data{std::move(_encoded_data)} {}
+  Base64Data(const char* ptr_encoded_data, size_t n)
+      : encoded_data(ptr_encoded_data, n) {}
+
   /** Is the data empty? */
   bool empty() const noexcept { return encoded_data.empty(); }
   /**

--- a/tessellate_ipu/lib/ipu_custom_primitive.hpp
+++ b/tessellate_ipu/lib/ipu_custom_primitive.hpp
@@ -13,11 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #pragma once
-#include <pybind11/numpy.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-
 #include <poplar/Graph.hpp>
 #include <poplar/Program.hpp>
 #include <poputil/exceptions.hpp>
@@ -163,6 +158,6 @@ class PrimitiveInterface {
 // Custom op API level default value.
 // Should not required to be changed for ops, only when upgrading Poplar SDK.
 extern "C" {
-// pybind11 using -fvisibility=hidden. Need to explicit export symbols.
+// pybind11/nanobind using -fvisibility=hidden. Need to explicit export symbols.
 __attribute__((visibility("default"))) int32_t custom_op_api_level = 5;
 }

--- a/tessellate_ipu/lib/poplin/conv_partial_vertex_utils_py.hpp
+++ b/tessellate_ipu/lib/poplin/conv_partial_vertex_utils_py.hpp
@@ -1,44 +1,45 @@
 // Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 #pragma once
 
-#include <pybind11/pybind11.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/pair.h>
 
 #include "ConvPartialsStridesPacking.hpp"
 
 namespace ipu {
 
 /**
- * @brief Make pybind11 bindings for IPU `dot` vertices utils.
+ * @brief Make nanobind bindings for IPU `dot` vertices utils.
  */
-inline decltype(auto) makeIpuDotVertexUtilsBindings(pybind11::module& m) {
+inline decltype(auto) makeIpuDotVertexUtilsBindings(nanobind::module_& m) {
   m.def("ipuGetTransformedInStride", &poplin::getTransformedInStride,
-        pybind11::arg("convUnitWeightHeight"), pybind11::arg("inStride"),
-        pybind11::arg("inRowStride"), pybind11::arg("convInputLoadElems"),
-        pybind11::arg("inChansPerGroup"));
+        nanobind::arg("convUnitWeightHeight"), nanobind::arg("inStride"),
+        nanobind::arg("inRowStride"), nanobind::arg("convInputLoadElems"),
+        nanobind::arg("inChansPerGroup"));
 
   m.def("ipuGetTransformedInRowStride", &poplin::getTransformedInRowStride,
-        pybind11::arg("inRowStride"), pybind11::arg("convInputLoadElems"),
-        pybind11::arg("inChansPerGroup"));
+        nanobind::arg("inRowStride"), nanobind::arg("convInputLoadElems"),
+        nanobind::arg("inChansPerGroup"));
 
   m.def("ipuGetTransformedOutStride", &poplin::getTransformedOutStride,
-        pybind11::arg("outStride"), pybind11::arg("outChansPerGroup"),
-        pybind11::arg("numConvUnitsRequired"), pybind11::arg("isPartialsFloat"),
-        pybind11::arg("flipOut"));
+        nanobind::arg("outStride"), nanobind::arg("outChansPerGroup"),
+        nanobind::arg("numConvUnitsRequired"), nanobind::arg("isPartialsFloat"),
+        nanobind::arg("flipOut"));
 
   m.def("ipuReverseTransformedInStride", &poplin::reverseTransformedInStride,
-        pybind11::arg("transformedInStride"),
-        pybind11::arg("convInputLoadElems"), pybind11::arg("inChansPerGroup"),
-        pybind11::arg("ampKernelHeight") = 0, pybind11::arg("inRowStride") = 0);
+        nanobind::arg("transformedInStride"),
+        nanobind::arg("convInputLoadElems"), nanobind::arg("inChansPerGroup"),
+        nanobind::arg("ampKernelHeight") = 0, nanobind::arg("inRowStride") = 0);
 
   m.def("ipuReverseTransformedInRowStride",
         &poplin::reverseTransformedInRowStride,
-        pybind11::arg("transformedInStride"),
-        pybind11::arg("convInputLoadElems"), pybind11::arg("inChansPerGroup"));
+        nanobind::arg("transformedInStride"),
+        nanobind::arg("convInputLoadElems"), nanobind::arg("inChansPerGroup"));
 
   m.def("ipuReverseTransformedOutStride", &poplin::reverseTransformedOutStride,
-        pybind11::arg("transformedOutStride"),
-        pybind11::arg("accumTypeIsFloat"), pybind11::arg("numConvUnits"),
-        pybind11::arg("outChansPerGroup"));
+        nanobind::arg("transformedOutStride"),
+        nanobind::arg("accumTypeIsFloat"), nanobind::arg("numConvUnits"),
+        nanobind::arg("outChansPerGroup"));
 }
 
 }  // namespace ipu

--- a/tessellate_ipu/lib/tessellate_ipu_core.cpp
+++ b/tessellate_ipu/lib/tessellate_ipu_core.cpp
@@ -4,161 +4,167 @@
 #include "tile_array_ops.hpp"
 #include "tile_map_ops_py.hpp"
 
-using namespace ipu;
+namespace nb = nanobind;
 
-PYBIND11_MODULE(pytessellate_ipu_core, m) {
+using namespace ipu;
+using namespace nb::literals;
+
+NB_MODULE(pytessellate_ipu_core, m) {
+  // Avoid leak warning from the library.
+  nanobind::set_leak_warnings(false);
   // Common base types bindings.
   makeIpuTypeBindings(m);
   makeShapeArrayBindings(m);
   makeBase64DataBindings(m);
 
+  // IPU conv partial vertex utils.
+  makeIpuDotVertexUtilsBindings(m);
+
   // Tile array operation parameters.
-  pybind11::class_<TileGatherParams>(m, "TileGatherParams")
-      .def(pybind11::init<>())
-      .def(pybind11::init<const TileArrayType&, const TileArrayType&,
+  nanobind::class_<TileGatherParams>(m, "TileGatherParams")
+      .def(nanobind::init<>())
+      .def(nanobind::init<const TileArrayType&, const TileArrayType&,
                           const TileArrayType&>(),
-           pybind11::arg("previous_tiles"), pybind11::arg("indices"),
-           pybind11::arg("tiles"))
+           nanobind::arg("previous_tiles"), nanobind::arg("indices"),
+           nanobind::arg("tiles"))
       .def("to_json_str",
            [](const TileGatherParams& v) { return to_json_str(v); })
       .def_static("from_json_str",
                   [](const std::string& j) {
                     return from_json_str<TileGatherParams>(j);
                   })
-      .def_readwrite("previous_tiles", &TileGatherParams::previous_tiles)
-      .def_readwrite("indices", &TileGatherParams::indices)
-      .def_readwrite("tiles", &TileGatherParams::tiles);
+      .def_rw("previous_tiles", &TileGatherParams::previous_tiles)
+      .def_rw("indices", &TileGatherParams::indices)
+      .def_rw("tiles", &TileGatherParams::tiles);
 
-  pybind11::class_<TileDataBarrierParams>(m, "TileDataBarrierParams")
-      .def(pybind11::init<>())
-      .def(pybind11::init<const std::string&, const std::vector<TileArrayType>&,
+  nanobind::class_<TileDataBarrierParams>(m, "TileDataBarrierParams")
+      .def(nanobind::init<>())
+      .def(nanobind::init<const std::string&, const std::vector<TileArrayType>&,
                           TileIndexType>(),
-           pybind11::arg("vname"), pybind11::arg("inputs_tiles"),
-           pybind11::arg("max_tile"))
+           nanobind::arg("vname"), nanobind::arg("inputs_tiles"),
+           nanobind::arg("max_tile"))
       .def("to_json_str",
            [](const TileDataBarrierParams& v) { return to_json_str(v); })
       .def_static("from_json_str",
                   [](const std::string& j) {
                     return from_json_str<TileDataBarrierParams>(j);
                   })
-      .def_readwrite("vname", &TileDataBarrierParams::vname)
-      .def_readwrite("inputs_tiles", &TileDataBarrierParams::inputs_tiles)
-      .def_readwrite("max_tile", &TileDataBarrierParams::max_tile);
+      .def_rw("vname", &TileDataBarrierParams::vname)
+      .def_rw("inputs_tiles", &TileDataBarrierParams::inputs_tiles)
+      .def_rw("max_tile", &TileDataBarrierParams::max_tile);
 
-  pybind11::class_<TileConstantParams>(m, "TileConstantParams")
-      .def(pybind11::init<>())
-      .def(pybind11::init<const ShapedArray&, const TileArrayType&,
+  nanobind::class_<TileConstantParams>(m, "TileConstantParams")
+      .def(nanobind::init<>())
+      .def(nanobind::init<const ShapedArray&, const TileArrayType&,
                           const Base64Data&>(),
-           pybind11::arg("aval"), pybind11::arg("tiles"), pybind11::arg("data"))
+           nanobind::arg("aval"), nanobind::arg("tiles"), nanobind::arg("data"))
       .def("to_json_str",
            [](const TileConstantParams& v) { return to_json_str(v); })
       .def_static("from_json_str",
                   [](const std::string& j) {
                     return from_json_str<TileConstantParams>(j);
                   })
-      .def_readwrite("aval", &TileConstantParams::aval)
-      .def_readwrite("tiles", &TileConstantParams::tiles)
-      .def_readwrite("data", &TileConstantParams::data);
-
-  // IPU vertex utils.
-  makeIpuDotVertexUtilsBindings(m);
+      .def_rw("aval", &TileConstantParams::aval)
+      .def_rw("tiles", &TileConstantParams::tiles)
+      .def_rw("data", &TileConstantParams::data);
 
   // Tile map ops bindings
-  pybind11::enum_<VertexIOType>(m, "IpuVertexIOType", pybind11::arithmetic())
+  nanobind::enum_<VertexIOType>(m, "IpuVertexIOType", nanobind::is_arithmetic())
       .value("In", VertexIOType::In)
       .value("Out", VertexIOType::Out)
       .value("InOut", VertexIOType::InOut);
   makeVertexAttributeBindings<int32_t>(m, "IpuVertexAttributeI32");
   makeVertexAttributeBindings<float>(m, "IpuVertexAttributeF32");
 
-  pybind11::class_<TensorSlice>(m, "IpuTensorSlice")
-      .def(pybind11::init<std::size_t, std::size_t>(), pybind11::arg("begin"),
-           pybind11::arg("end"))
-      .def_readwrite("begin", &TensorSlice::begin)
-      .def_readwrite("end", &TensorSlice::end)
+  nanobind::class_<TensorSlice>(m, "IpuTensorSlice")
+      .def(nanobind::init<std::size_t, std::size_t>(), nanobind::arg("begin"),
+           nanobind::arg("end"))
+      .def_rw("begin", &TensorSlice::begin)
+      .def_rw("end", &TensorSlice::end)
       .def_static("make_tensor2d_slices", &TensorSlice::makeTensor2dSlices)
       .def("to_json_str", [](const TensorSlice& v) { return to_json_str(v); })
       .def_static("from_json_str", [](const std::string& j) {
         return from_json_str<TensorSlice>(j);
       });
 
-  pybind11::class_<VertexIOInfo>(m, "IpuVertexIOInfo")
-      .def(pybind11::init<>())
-      .def(pybind11::init<const std::string&, VertexIOType, const ShapedArray&,
+  nanobind::class_<VertexIOInfo>(m, "IpuVertexIOInfo")
+      .def(nanobind::init<>())
+      // FIXME: Base64Data(), std::vector<TensorSlice>() default args.
+      .def(nanobind::init<const std::string&, VertexIOType, const ShapedArray&,
                           const Base64Data&, const std::vector<TensorSlice>&>(),
-           pybind11::arg("name"), pybind11::arg("iotype"),
-           pybind11::arg("aval"), pybind11::arg("constant_data") = Base64Data(),
-           pybind11::arg("slices2d") = std::vector<TensorSlice>())
-      .def(pybind11::init<const std::string&, VertexIOType, const ShapeType&,
+           nanobind::arg("name"), nanobind::arg("iotype"),
+           nanobind::arg("aval"), nanobind::arg("constant_data"),
+           nanobind::arg("slices2d"))
+      .def(nanobind::init<const std::string&, VertexIOType, const ShapeType&,
                           IpuType, const Base64Data&,
                           const std::vector<TensorSlice>&>(),
-           pybind11::arg("name"), pybind11::arg("iotype"),
-           pybind11::arg("shape"), pybind11::arg("dtype"),
-           pybind11::arg("constant_data") = Base64Data(),
-           pybind11::arg("slices2d") = std::vector<TensorSlice>())
-      .def(pybind11::init(&VertexIOInfo::makeVertexIOInfo),
-           pybind11::arg("name"), pybind11::arg("iotype"),
-           pybind11::arg("shape"), pybind11::arg("dtype"),
-           pybind11::arg("vertex_dim2") = 0,
-           pybind11::arg("constant_data") = Base64Data())
-      .def(pybind11::self == pybind11::self)
+           nanobind::arg("name"), nanobind::arg("iotype"),
+           nanobind::arg("shape"), nanobind::arg("dtype"),
+           nanobind::arg("constant_data"), nanobind::arg("slices2d"))
+      .def(nanobind::init<const std::string&, VertexIOType, const ShapeType&,
+                          IpuType, std::size_t, const Base64Data&>(),
+           nanobind::arg("name"), nanobind::arg("iotype"),
+           nanobind::arg("shape"), nanobind::arg("dtype"),
+           nanobind::arg("vertex_dim2") = 0,
+           nanobind::arg("constant_data") = Base64Data())
+      .def("__eq__", [](const VertexIOInfo& lhs,
+                        const VertexIOInfo& rhs) { return lhs == rhs; })
       .def("to_json_str", [](const VertexIOInfo& v) { return to_json_str(v); })
       .def_static(
           "from_json_str",
           [](const std::string& j) { return from_json_str<VertexIOInfo>(j); })
-      .def_readwrite("name", &VertexIOInfo::name)
-      .def_readwrite("iotype", &VertexIOInfo::iotype)
-      .def_readwrite("aval", &VertexIOInfo::aval)
-      .def_readwrite("constant_data", &VertexIOInfo::constant_data)
-      .def_readwrite("slices2d", &VertexIOInfo::slices2d)
-      .def_property_readonly("shape",
-                             [](const VertexIOInfo& v) { return v.aval.shape; })
-      .def_property_readonly("dtype",
-                             [](const VertexIOInfo& v) { return v.aval.dtype; })
-      .def_property_readonly("is_constant_input",
-                             &VertexIOInfo::isConstantInput);
+      .def_rw("name", &VertexIOInfo::name)
+      .def_rw("iotype", &VertexIOInfo::iotype)
+      .def_rw("aval", &VertexIOInfo::aval)
+      .def_rw("constant_data", &VertexIOInfo::constant_data)
+      .def_rw("slices2d", &VertexIOInfo::slices2d)
+      .def_prop_ro("shape", [](const VertexIOInfo& v) { return v.aval.shape; })
+      .def_prop_ro("dtype", [](const VertexIOInfo& v) { return v.aval.dtype; })
+      .def_prop_ro("is_constant_input", &VertexIOInfo::isConstantInput);
 
-  pybind11::class_<TileMapEquation>(m, "IpuTileMapEquation")
-      .def(pybind11::init<>())
-      .def(pybind11::init<
-               const std::string& /* pname */, const std::string& /* vname */,
-               const std::vector<TileIndexType>& /* tiles */,
-               const std::vector<VertexIOInfo>& /* inputs_info */,
-               const std::vector<VertexIOInfo>& /* outputs_info */,
-               const std::vector<VertexAttributeI32>& /* attributes_i32 */,
-               const std::vector<VertexAttributeF32>& /* attributes_f32 */,
-               const std::string& /* tmp_space_name */,
-               const ShapedArray& /* tmp_space_aval */,
-               const std::string& /* gp_filename */,
-               uint64_t /* perf_estimate */, bool /* sync */>(),
-           pybind11::arg("pname"), pybind11::arg("vname"),
-           pybind11::arg("tiles"),
-           pybind11::arg("inputs_info") = std::vector<VertexIOInfo>(),
-           pybind11::arg("outputs_info") = std::vector<VertexIOInfo>(),
-           pybind11::arg("attributes_i32") = std::vector<VertexAttributeI32>(),
-           pybind11::arg("attributes_f32") = std::vector<VertexAttributeF32>(),
-           pybind11::arg("tmp_space_name") = "",
-           pybind11::arg("tmp_space_aval") =
+  nanobind::class_<TileMapEquation>(m, "IpuTileMapEquation")
+      .def(nanobind::init<>())
+      .def(nanobind::init<
+               const std::string&,                      // pname
+               const std::string&,                      // vname
+               const std::vector<TileIndexType>&,       // tiles
+               const std::vector<VertexIOInfo>&,        // inputs_info
+               const std::vector<VertexIOInfo>&,        // outputs_info
+               const std::vector<VertexAttributeI32>&,  // attributes_i32
+               const std::vector<VertexAttributeF32>&,  // attributes_f32
+               const std::string&,                      // tmp_space_name
+               const ShapedArray&,                      // tmp_space_aval
+               const std::string&,                      // gp_filename
+               uint64_t,                                // perf_estimate
+               bool>(),                                 // sync
+           nanobind::arg("pname"), nanobind::arg("vname"),
+           nanobind::arg("tiles"),
+           nanobind::arg("inputs_info") = std::vector<VertexIOInfo>(),
+           nanobind::arg("outputs_info") = std::vector<VertexIOInfo>(),
+           nanobind::arg("attributes_i32") = std::vector<VertexAttributeI32>(),
+           nanobind::arg("attributes_f32") = std::vector<VertexAttributeF32>(),
+           nanobind::arg("tmp_space_name") = "",
+           nanobind::arg("tmp_space_aval") =
                ShapedArray{{0}, IpuType::UNSIGNED_CHAR},
-           pybind11::arg("gp_filename") = "",
-           pybind11::arg("perf_estimate") = 0, pybind11::arg("sync") = false)
+           nanobind::arg("gp_filename") = "",
+           nanobind::arg("perf_estimate") = 0, nanobind::arg("sync") = false)
       .def("to_json_str",
            [](const TileMapEquation& v) { return to_json_str(v); })
       .def_static("from_json_str",
                   [](const std::string& j) {
                     return from_json_str<TileMapEquation>(j);
                   })
-      .def_readwrite("pname", &TileMapEquation::pname)
-      .def_readwrite("vname", &TileMapEquation::vname)
-      .def_readwrite("tiles", &TileMapEquation::tiles)
-      .def_readwrite("inputs_info", &TileMapEquation::inputs_info)
-      .def_readwrite("outputs_info", &TileMapEquation::outputs_info)
-      .def_readwrite("attributes_i32", &TileMapEquation::attributes_i32)
-      .def_readwrite("attributes_f32", &TileMapEquation::attributes_f32)
-      .def_readwrite("tmp_space_name", &TileMapEquation::tmp_space_name)
-      .def_readwrite("tmp_space_aval", &TileMapEquation::tmp_space_aval)
-      .def_readwrite("gp_filename", &TileMapEquation::gp_filename)
-      .def_readwrite("perf_estimate", &TileMapEquation::perf_estimate)
-      .def_readwrite("sync", &TileMapEquation::sync)
-      .def_property_readonly("use_tmp_space", &TileMapEquation::useTmpSpace);
+      .def_rw("pname", &TileMapEquation::pname)
+      .def_rw("vname", &TileMapEquation::vname)
+      .def_rw("tiles", &TileMapEquation::tiles)
+      .def_rw("inputs_info", &TileMapEquation::inputs_info)
+      .def_rw("outputs_info", &TileMapEquation::outputs_info)
+      .def_rw("attributes_i32", &TileMapEquation::attributes_i32)
+      .def_rw("attributes_f32", &TileMapEquation::attributes_f32)
+      .def_rw("tmp_space_name", &TileMapEquation::tmp_space_name)
+      .def_rw("tmp_space_aval", &TileMapEquation::tmp_space_aval)
+      .def_rw("gp_filename", &TileMapEquation::gp_filename)
+      .def_rw("perf_estimate", &TileMapEquation::perf_estimate)
+      .def_rw("sync", &TileMapEquation::sync)
+      .def_prop_ro("use_tmp_space", &TileMapEquation::useTmpSpace);
 }

--- a/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
+++ b/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2022 Graphcore Ltd. All rights reserved.
-#include "base_types.hpp"
+#include <nanobind/nanobind.h>
+
 #include "ipu_custom_primitive.hpp"
 #include "tile_array_ops.hpp"
 #include "tile_map_ops.hpp"
@@ -221,31 +222,18 @@ class TileMapEquationCall : public jax::ipu::PrimitiveInterface {
 // Export the IPU JAX primitives in the shared library.
 EXPORT_IPU_JAX_PRIMITIVE(TileMapEquationCall);
 
-PYBIND11_MODULE(pytessellate_ipu_ops_jax, m) {
+NB_MODULE(pytessellate_ipu_ops_jax, m) {
+  // Avoid leak warning from the library.
+  nanobind::set_leak_warnings(false);
   // Tile array operations.
-  pybind11::class_<TilePutShardedPrimitive>(m, "TilePutShardedPrimitive")
-      .def_static("metadata", &TilePutShardedPrimitive::metadata,
-                  pybind11::arg("num_inputs"));
-  pybind11::class_<TilePutReplicatedPrimitive>(m, "TilePutReplicatedPrimitive")
-      .def_static("metadata", &TilePutReplicatedPrimitive::metadata,
-                  pybind11::arg("num_inputs"));
-  pybind11::class_<TileGatherPrimitive>(m, "TileGatherPrimitive")
-      .def_static("metadata", &TileGatherPrimitive::metadata,
-                  pybind11::arg("num_inputs"));
-  pybind11::class_<TileDataBarrierPrimitive>(m, "TileDataBarrierPrimitive")
-      .def_static("metadata", &TileDataBarrierPrimitive::metadata,
-                  pybind11::arg("num_inputs"));
-  pybind11::class_<TileConstantReplicatedPrimitive>(
-      m, "TileConstantReplicatedPrimitive")
-      .def_static("metadata", &TileConstantReplicatedPrimitive::metadata,
-                  pybind11::arg("num_inputs"));
-  pybind11::class_<TileConstantShardedPrimitive>(m,
-                                                 "TileConstantShardedPrimitive")
-      .def_static("metadata", &TileConstantShardedPrimitive::metadata,
-                  pybind11::arg("num_inputs"));
-
+  nanobind::class_<TilePutShardedPrimitive>(m, "TilePutShardedPrimitive");
+  nanobind::class_<TilePutReplicatedPrimitive>(m, "TilePutReplicatedPrimitive");
+  nanobind::class_<TileGatherPrimitive>(m, "TileGatherPrimitive");
+  nanobind::class_<TileDataBarrierPrimitive>(m, "TileDataBarrierPrimitive");
+  nanobind::class_<TileConstantReplicatedPrimitive>(
+      m, "TileConstantReplicatedPrimitive");
+  nanobind::class_<TileConstantShardedPrimitive>(
+      m, "TileConstantShardedPrimitive");
   // Tile map operations.
-  pybind11::class_<TileMapEquationCall>(m, "TileMapEquationCall")
-      .def_static("metadata", &TileMapEquationCall::metadata,
-                  pybind11::arg("num_inputs"));
+  nanobind::class_<TileMapEquationCall>(m, "TileMapEquationCall");
 }

--- a/tessellate_ipu/lib/tile_map_ops.hpp
+++ b/tessellate_ipu/lib/tile_map_ops.hpp
@@ -62,6 +62,48 @@ struct VertexIOInfo {
   /** Slices, in the case of 2d tensor input. */
   std::vector<TensorSlice> slices2d;
 
+  /** Default constructors/assignment. */
+  VertexIOInfo() noexcept = default;
+  VertexIOInfo(VertexIOInfo&&) noexcept = default;
+  VertexIOInfo(const VertexIOInfo&) = default;
+  VertexIOInfo& operator=(VertexIOInfo&&) noexcept = default;
+  VertexIOInfo& operator=(const VertexIOInfo&) = default;
+
+  VertexIOInfo(const std::string& _name, VertexIOType _iotype,
+               const ShapeType& _shape, IpuType _dtype,
+               const Base64Data& _constant_data,
+               const std::vector<TensorSlice>& _slices2d)
+      : name{_name},
+        iotype{_iotype},
+        aval{_shape, _dtype},
+        constant_data{_constant_data},
+        slices2d{_slices2d} {}
+
+  VertexIOInfo(const std::string& _name, VertexIOType _iotype,
+               const ShapedArray& _aval, const Base64Data& _constant_data,
+               const std::vector<TensorSlice>& _slices2d)
+      : name{_name},
+        iotype{_iotype},
+        aval{_aval},
+        constant_data{_constant_data},
+        slices2d{_slices2d} {}
+  /**
+   * @brief Build a vertex IO info (with vertex second dim info).
+   */
+  VertexIOInfo(const std::string& _name, VertexIOType _iotype,
+               const ShapeType& _shape, IpuType _dtype,
+               std::size_t _vertex_dim2, const Base64Data& _constant_data)
+      : name{_name},
+        iotype{_iotype},
+        aval{_shape, _dtype},
+        constant_data{_constant_data} {
+    // Generate 2d slices when required.
+    if (_vertex_dim2 > 0) {
+      slices2d = TensorSlice::makeTensor2dSlices(aval.size() / _vertex_dim2,
+                                                 _vertex_dim2);
+    }
+  }
+
   /**
    * @brief Build a vertex IO info (with vertex second dim info).
    */

--- a/tessellate_ipu/lib/tile_map_ops_py.hpp
+++ b/tessellate_ipu/lib/tile_map_ops_py.hpp
@@ -1,11 +1,10 @@
 // Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 #pragma once
-#include <pybind11/numpy.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
 
 #include "tile_map_ops.hpp"
+
+namespace nb = nanobind;
 
 namespace ipu {
 
@@ -13,20 +12,21 @@ namespace ipu {
  * @brief Make Python bindings of VertexAttribute class.
  */
 template <typename T>
-decltype(auto) makeVertexAttributeBindings(pybind11::module& m,
+decltype(auto) makeVertexAttributeBindings(nanobind::module_& m,
                                            const char* name) {
   using VertexAttrType = VertexAttribute<T>;
-  pybind11::class_<VertexAttrType>(m, name)
-      .def(pybind11::init<>())
-      .def(pybind11::init<const std::string&, T>(), pybind11::arg("name"),
-           pybind11::arg("value"))
-      .def(pybind11::self == pybind11::self)
+  nanobind::class_<VertexAttrType>(m, name)
+      .def(nanobind::init<>())
+      .def(nanobind::init<const std::string&, T>(), nanobind::arg("name"),
+           nanobind::arg("value"))
+      .def("__eq__", [](const VertexAttrType& lhs,
+                        const VertexAttrType& rhs) { return lhs == rhs; })
       .def("to_json_str",
            [](const VertexAttrType& v) { return to_json_str(v); })
       .def_static(
           "from_json_str",
           [](const std::string& j) { return from_json_str<VertexAttrType>(j); })
-      .def_readwrite("name", &VertexAttrType::name)
-      .def_readwrite("value", &VertexAttrType::value);
+      .def_rw("name", &VertexAttrType::name)
+      .def_rw("value", &VertexAttrType::value);
 }
 }  // namespace ipu

--- a/tests/core/test_tile_array_primitives.py
+++ b/tests/core/test_tile_array_primitives.py
@@ -6,11 +6,8 @@ import numpy.testing as npt
 import pytest
 from absl.testing import parameterized
 
-from tessellate_ipu.core.tile_array_primitives import (
-    TileDataBarrierParams,
-    tile_put_replicated_prim,
-    tile_put_sharded_prim,
-)
+from tessellate_ipu.core.tile_array_primitives import tile_put_replicated_prim, tile_put_sharded_prim
+from tessellate_ipu.lib.pytessellate_ipu_core import TileDataBarrierParams
 
 
 class TilePutShardedPrimTests(chex.TestCase, parameterized.TestCase):


### PR DESCRIPTION
Nanobind offers a couple of benefits compared to pybind11.
In particular compilation speed (2x), binaries size and performance.
See: https://nanobind.readthedocs.io/en/latest/why.html

This PR is porting TessellateIPU to Nanobind library. Most pybind11 APIs
have a 1-to-1 equivalent in Nanobind. The main issue happened to be leaked
references during Python shutdown, where JAX MLIR registration and Python typing
module interfere with proper reference counting. In most cases, the issue should
be now solved, but still persist in some situations (e.g. pytest running?)