### PR TITLE
Support properly inplace unary/binary Tessellate operations.

### DIFF
--- a/examples/demo/demo_inplace_loop.py
+++ b/examples/demo/demo_inplace_loop.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from functools import partial
+
+import jax
+import numpy as np
+
+from tessellate_ipu import tile_map, tile_put_sharded
+from tessellate_ipu.lax import sqrt_inplace_p
+
+data = np.array([1, 2, 3], np.float32)
+tiles = (1, 2, 5)
+
+
+def inner(_, carry):
+    # Inplace operation optimal for loops on IPU.
+    # Keep re-using the same buffer, no additional copy required.
+    return tile_map(sqrt_inplace_p, carry)
+
+
+@partial(jax.jit, backend="ipu")
+def compute_fn(input):
+    x = tile_put_sharded(input, tiles)
+    x = jax.lax.fori_loop(0, 4, inner, x)
+    return x
+
+
+output = compute_fn(data)
+print(output)
+print(output, output.array.device())
+print("SHAPE:", output.shape)
+print("RESULT:", output.array)

--- a/tessellate_ipu/core/__init__.py
+++ b/tessellate_ipu/core/__init__.py
@@ -18,6 +18,7 @@ from .tile_interpreter import (
     create_ipu_tile_primitive,
     create_ipu_tile_primitive_v2,
     declare_ipu_tile_primitive,
+    get_ipu_tile_primitive_translation,
     register_ipu_tile_primitive,
     tile_map,
 )
@@ -41,6 +42,8 @@ from .tile_interpreter_primitives import (
     make_ipu_vertex_name_templated,
     make_ipu_vertex_out_info,
     make_ipu_vertex_outputs,
+    primitive_clone,
+    primitive_num_inout_alias_args,
 )
 
 

--- a/tessellate_ipu/lax/__init__.py
+++ b/tessellate_ipu/lax/__init__.py
@@ -1,7 +1,63 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 # Register JAX primitives for tile interpreter.
+from jax.lax import (
+    abs_p,
+    asin_p,
+    cbrt_p,
+    ceil_p,
+    erf_p,
+    exp_p,
+    expm1_p,
+    floor_p,
+    is_finite_p,
+    log1p_p,
+    log_p,
+    neg_p,
+    population_count_p,
+    round_p,
+    rsqrt_p,
+    sign_p,
+    sin_p,
+    sqrt_p,
+    tan_p,
+    tanh_p,
+)
+
 from . import tile_lax_binary, tile_lax_dot, tile_lax_reduce, tile_lax_unary, tile_random
-from .tile_lax_binary import scaled_add_p, scaled_sub_p
+from .tile_lax_binary import (
+    add_inplace_p,
+    atan2_inplace_p,
+    div_inplace_p,
+    max_inplace_p,
+    min_inplace_p,
+    mul_inplace_p,
+    pow_inplace_p,
+    rem_inplace_p,
+    scaled_add_p,
+    scaled_sub_p,
+    sub_inplace_p,
+)
 from .tile_lax_dot import IpuConvVertexType
-from .tile_lax_unary import tile_copy
+from .tile_lax_unary import (  # tanh_inplace_p,
+    abs_inplace_p,
+    asin_inplace_p,
+    cbrt_inplace_p,
+    ceil_inplace_p,
+    erf_inplace_p,
+    exp_inplace_p,
+    expm1_inplace_p,
+    floor_inplace_p,
+    is_finite_inplace_p,
+    log1p_inplace_p,
+    log_inplace_p,
+    neg_inplace_p,
+    population_count_inplace_p,
+    round_inplace_p,
+    rsqrt_inplace_p,
+    sign_inplace_p,
+    sin_inplace_p,
+    sqrt_inplace_p,
+    tan_inplace_p,
+    tile_copy,
+)
 from .tile_random import tile_get_hw_seeds, tile_random_normal, tile_random_uniform, tile_set_hw_seeds

--- a/tessellate_ipu/lax/tile_lax_binary.py
+++ b/tessellate_ipu/lax/tile_lax_binary.py
@@ -7,13 +7,16 @@ from jax.core import Primitive, ShapedArray
 
 from tessellate_ipu.core import (
     IpuTileMapEquation,
+    get_ipu_tile_primitive_translation,
     get_ipu_type_name,
     make_ipu_vertex_attributes,
     make_ipu_vertex_in_info,
     make_ipu_vertex_inout_info,
     make_ipu_vertex_out_info,
+    primitive_clone,
     register_ipu_tile_primitive,
 )
+from tessellate_ipu.core.tile_interpreter_primitives import primitive_num_inout_alias_args
 from tessellate_ipu.utils import DTypeLike
 
 # popops definitions.
@@ -73,10 +76,28 @@ _binary_primitive_to_vertex_basename: Dict[Primitive, Tuple[str, Any]] = {
 """
 
 
-def make_binary1d_vertex_fullname(basename: str, dtype: DTypeLike) -> str:
-    """Create the full vertex name from the basename and dtype."""
+def make_binary1d_vertex_fullname(basename: str, dtype: DTypeLike, inplace: bool = False) -> str:
+    """Create the full vertex name from the basename, dtype and inplace."""
     ipu_dtype = get_ipu_type_name(dtype)
-    return f"popops::BinaryOp1D<popops::expr::BinaryOpType::{basename},{ipu_dtype}>"
+    binary_basename = "BinaryOp1DInPlace" if inplace else "BinaryOp1D"
+    return f"popops::{binary_basename}<popops::expr::BinaryOpType::{basename},{ipu_dtype}>"
+
+
+def make_binary1d_vertex_io_infos(
+    inavals: List[ShapedArray], outaval: ShapedArray, inplace: bool
+) -> Tuple[List[Any], List[Any]]:
+    """Build Poplibs binary vertex IO infos.
+
+    Naming of the vertex interface depends on whether it is inplace or not.
+    """
+    if inplace:
+        return [make_ipu_vertex_inout_info("in1Out", inavals[0]), make_ipu_vertex_in_info("in2", inavals[1])], [
+            make_ipu_vertex_inout_info("in1Out", outaval)
+        ]
+    else:
+        return [make_ipu_vertex_in_info("in1", inavals[0]), make_ipu_vertex_in_info("in2", inavals[1])], [
+            make_ipu_vertex_out_info("out", outaval)
+        ]
 
 
 def ipu_binary_primitive_translation(
@@ -97,17 +118,17 @@ def ipu_binary_primitive_translation(
     """
     assert len(inavals) == 2
     vertex_basename, outdtype = _binary_primitive_to_vertex_basename[p]
-    vname = make_binary1d_vertex_fullname(vertex_basename, inavals[0].dtype)
+    # Is it an inplace primitive?
+    inplace_prim = primitive_num_inout_alias_args(p) > 0
+    vname = make_binary1d_vertex_fullname(vertex_basename, inavals[0].dtype, inplace_prim)
     outaval = ShapedArray(inavals[0].shape, outdtype or inavals[0].dtype)
+    inputs_info, outputs_info = make_binary1d_vertex_io_infos(inavals, outaval, inplace_prim)
     ipu_prim_info = IpuTileMapEquation(
         vname=vname,
         pname=p.name,
         tiles=tiles,
-        inputs_info=[
-            make_ipu_vertex_in_info("in1", inavals[0]),
-            make_ipu_vertex_in_info("in2", inavals[1]),
-        ],
-        outputs_info=[make_ipu_vertex_out_info("out", outaval)],
+        inputs_info=inputs_info,
+        outputs_info=outputs_info,
         attributes_i32=[],
         attributes_f32=[],
     )
@@ -228,3 +249,31 @@ scaled_sub_p.def_abstract_eval(scaled_op_abstract_eval)
 # Register tile IPU translation.
 register_ipu_tile_primitive(scaled_add_p, scale_add_tile_translation_ipu)
 register_ipu_tile_primitive(scaled_sub_p, scale_sub_tile_translation_ipu)
+
+
+def register_ipu_binary_inplace_tile_primitive(orig_prim):
+    """Create and register IPU unary inplace tile primitive.
+
+    Args:
+        orig_prim: Original non-inplace unary primitive.
+    Returns:
+        Inplace unary primitive, registered.
+    """
+    inplace_prim = primitive_clone(orig_prim, f"{orig_prim.name}_inplace")
+    _, tl_translation = get_ipu_tile_primitive_translation(orig_prim.name)
+    register_ipu_tile_primitive(inplace_prim, tl_translation)
+    _binary_primitive_to_vertex_basename[inplace_prim] = _binary_primitive_to_vertex_basename[orig_prim]
+    inplace_prim.num_inout_alias_args = 1
+    return inplace_prim
+
+
+# Inplace variants of support JAX LAX unary ops.
+add_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.add_p)
+atan2_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.atan2_p)
+div_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.div_p)
+max_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.max_p)
+min_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.min_p)
+mul_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.mul_p)
+pow_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.pow_p)
+rem_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.rem_p)
+sub_inplace_p = register_ipu_binary_inplace_tile_primitive(lax.sub_p)

--- a/tests/lib/test_tessellate_ops_jax.py
+++ b/tests/lib/test_tessellate_ops_jax.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+from tessellate_ipu.lib.pytessellate_ipu_ops_jax import TileMapMaxInOutAliasingArgs  # noqa: E402
+
+
+def test__tesselate_jax__max_inout_aliasing_args():
+    assert TileMapMaxInOutAliasingArgs == 2


### PR DESCRIPTION
JAX `tile_map` custom primitive has been updated to provide proper aliasing information
to the XLA backend.

TessellateIPU LAX unary and binary primitives now have inplace variants (e.g. `add_inplace_p`) where
the first argument is modified inplace. A unit test is checking that optimal performance is achieved
when used in a `fori_loop`, i.e. no additional copy is added by Poplar in the loop body.