### PR TITLE
WIP: Improving jacobi

### DIFF
--- a/tessellate_ipu/linalg/tile_linalg_jacobi.py
+++ b/tessellate_ipu/linalg/tile_linalg_jacobi.py
@@ -139,7 +139,6 @@ def ipu_jacobi_eigh_iteration(all_AV_cols: Tuple[Array, ...], Atiles: Any, Vtile
     rotset = jacobi_initial_rotation_set(N)
 
     # All different size 2 partitions on columns.
-    from tqdm import tqdm 
     def iteration(i, vals): 
         rotset, Apcols, Aqcols, Aqcols, Vpcols, Vqcols = vals 
 
@@ -190,6 +189,7 @@ def ipu_jacobi_eigh_iteration(all_AV_cols: Tuple[Array, ...], Atiles: Any, Vtile
     # TODO: decide if we want to support unrolled version. 
     unroll = False 
     if unroll: 
+        from tqdm import tqdm 
         for i in tqdm(range(1, N)): # is this done all in parallel? 
             rotset, Apcols, Aqcols, Aqcols, Vpcols, Vqcols = iteration(i, [rotset, Apcols, Aqcols, Aqcols, Vpcols, Vqcols] )
     else: 


### PR DESCRIPTION
Turning https://github.com/graphcore-research/tessellate-ipu/issues/21 into PR as request by @awf 

Tough questions we may need to address: 

1. Do we want to retain control over [unroll vs jax.lax.fori_loop](https://github.com/graphcore-research/tessellate-ipu/blob/5d1187a3f9ac4ea663e142b22746dc592533477a/tessellate_ipu/linalg/tile_linalg_jacobi.py#L191)? Is there any performance difference?
2. Creating the popvision profile took ~10min for N=512. Suspect cause is nested `jax.lax.fori_loop` with 512*15 iterations. 
3. Do we want to allow user to between np and jnp when computing rotset (i.e. do at trace time or on-the-fly). This may allow a trade-off between memory/speed useful for small/larger matrices. Could be achieved with `def ipu_eigh(..., np_backend=jax.numpy)`.