### PR TITLE
Improve TessellateIPU `gather` support.

### DIFF
--- a/tests/lax/test_tile_lax_gather.py
+++ b/tests/lax/test_tile_lax_gather.py
@@ -13,7 +13,7 @@ from tessellate_ipu.lax import gather_p
 
 
 @pytest.mark.ipu_hardware
-class IpuTilePrimitivesLaxGather(chex.TestCase, parameterized.TestCase):
+class IpuTilePrimitivesLaxGatherHwTests(chex.TestCase, parameterized.TestCase):
     def setUp(self):
         super().setUp()
         self.device = jax.devices("ipu")[0]
@@ -22,18 +22,22 @@ class IpuTilePrimitivesLaxGather(chex.TestCase, parameterized.TestCase):
         np.random.seed(123)
 
     @parameterized.parameters(
-        {"num_elements": 8, "num_indices": 3},
-        {"num_elements": 8, "num_indices": 12},
-        {"num_elements": 256, "num_indices": 512},
+        {"data_shape": (8,), "num_indices": 3},
+        {"data_shape": (8,), "num_indices": 12},
+        {"data_shape": (256,), "num_indices": 512},
+        {"data_shape": (256, 17), "num_indices": 123},
+        {"data_shape": (256, 5, 3), "num_indices": 373},
     )
-    def test__tile_map__gather__jitting__proper_result(self, num_elements, num_indices):
+    def test__tile_map__gather__first_axis_cases__jitting__proper_result(self, data_shape, num_indices):
         tiles = (0,)
-        data = np.random.randn(num_elements).astype(np.float32)
-        indices = np.random.randint(low=0, high=num_elements, size=num_indices)
+        data = np.random.randn(*data_shape).astype(np.float32)
+        indices = np.random.randint(low=0, high=data_shape[0], size=num_indices)
         indices = indices.reshape(-1, 1).astype(np.uint32)
 
-        # Only supported configuration!
-        dim_numbers = jax.lax.GatherDimensionNumbers(offset_dims=(), collapsed_slice_dims=(0,), start_index_map=(0,))
+        # First axis gather only supported configuration!
+        dim_numbers = jax.lax.GatherDimensionNumbers(
+            offset_dims=tuple(range(1, len(data_shape))), collapsed_slice_dims=(0,), start_index_map=(0,)
+        )
 
         def gather_fn(data, indices):
             data = tile_put_replicated(data, tiles)
@@ -43,7 +47,7 @@ class IpuTilePrimitivesLaxGather(chex.TestCase, parameterized.TestCase):
                 data,
                 indices,
                 dimension_numbers=dim_numbers,
-                slice_sizes=(1,),
+                slice_sizes=(1, *data_shape[1:]),
                 mode=jax.lax.GatherScatterMode.PROMISE_IN_BOUNDS,
                 unique_indices=False,
                 indices_are_sorted=False,


### PR DESCRIPTION
Now fully supporting `gather` on the first axis, for any input shape.
Should allow to programmatically implement GPT-like on device embeddings using TessellateIPU.