### PR TITLE
Improve TessellateIPU `tile_map` debug context naming (compute sets & tensors)

### DIFF
--- a/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
+++ b/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 #include <nanobind/nanobind.h>
 
+#include <iostream>
+
 #include "ipu_custom_primitive.hpp"
 #include "tile_array_ops.hpp"
 #include "tile_map_ops.hpp"
@@ -238,11 +240,10 @@ class TileMapEquationCall : public jax::ipu::PrimitiveInterface {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debug_context = poplar::DebugContext(debug_prefix);
     const auto tile_equation =
         ipu::from_json_str<ipu::TileMapEquation>(attributes);
     return lowerTileMapCallToPoplar(graph, inputs, outputs, tile_equation,
-                                    debug_context);
+                                    debug_prefix);
   }
 };
 

--- a/tessellate_ipu/lib/tile_map_ops.hpp
+++ b/tessellate_ipu/lib/tile_map_ops.hpp
@@ -268,7 +268,8 @@ struct TileMapEquation {
    * @return Collection of input tensors.
    */
   std::vector<poplar::Tensor> allocateInputTensors(
-      poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs) const;
+      poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+      const poplar::DebugContext& debug_context) const;
 
   /**
    * @brief Allocate output (or use existing input) tensors.
@@ -277,13 +278,14 @@ struct TileMapEquation {
    * @return Collection of output tensors.
    */
   std::vector<poplar::Tensor> allocateOutputTensors(
-      poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs) const;
+      poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
+      const poplar::DebugContext& debug_context) const;
 
   /**
    * @brief Allocate the temporary-scratch space tensor (if used).
    */
   std::optional<poplar::Tensor> allocateTmpSpaceTensor(
-      poplar::Graph& graph) const;
+      poplar::Graph& graph, const poplar::DebugContext& debug_context) const;
 
   /**
    * @brief Add vertex/equation to Poplar graph & compute set.
@@ -334,12 +336,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(TileMapEquation, pname, vname, tiles,
  * @param inputs List of inputs.
  * @param outputs List of outputs, to update.
  * @param tile_map_eqn TileMapEquation info.
- * @param debug_context Poplar debug context.
+ * @param debug_prefix Poplar (raw) debug prefix.
  * @return Poplar program.
  */
 poplar::program::Program lowerTileMapCallToPoplar(
     poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
     std::vector<poplar::Tensor>& outputs, const TileMapEquation& tile_map_eqn,
-    const poplar::DebugContext& debug_context);
+    const std::string& debug_prefix);
 
 }  // namespace ipu


### PR DESCRIPTION
This PR improves on a couple of debug naming aspects in TessellateIPU:
* Generating readable name for `tile_map` operations (discarding metadata);
* Proper naming of outputs;

This improves massively the readability of a Popvision profile from a program using TessellateIPU.