### PR TITLE
Improve TessellateIPU variables naming (and profile duplication)

### DIFF
--- a/tessellate_ipu/lax/tile_lax_array.py
+++ b/tessellate_ipu/lax/tile_lax_array.py
@@ -216,8 +216,10 @@ def tile_sharded_identity(dtype: DTypeLike, tiles: Tuple[int, ...]) -> TileShard
         # Build zero matrix + update diagonal entries.
         arr = tile_fill((N,), 0, dtype=dtype, tiles=tiles)
         # Requiring constants for indices + updates. Something more efficient?s
-        indices = tile_constant_sharded(np.arange(0, N, dtype=np.uint32).reshape(N, 1, 1), tiles=tiles)
-        updates = tile_constant_replicated(np.array([1], dtype=dtype), tiles=tiles)
+        with jax.named_scope("indices"):
+            indices = tile_constant_sharded(np.arange(0, N, dtype=np.uint32).reshape(N, 1, 1), tiles=tiles)
+        with jax.named_scope("updates"):
+            updates = tile_constant_replicated(np.array([1], dtype=dtype), tiles=tiles)
         # Not the simplest way ever of updating diagonal terms!
         scatter_dnums = jax.lax.ScatterDimensionNumbers(
             update_window_dims=(), inserted_window_dims=(0,), scatter_dims_to_operand_dims=(0,)

--- a/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
+++ b/tessellate_ipu/lib/tessellate_ipu_ops_jax.cpp
@@ -42,7 +42,8 @@ class TilePutShardedPrimitive : public TilePutBase {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debug_context = poplar::DebugContext(debug_prefix);
+    const auto debug_context = poplar::DebugContext(
+        makeTileOpDebugPrefix(debug_prefix, "tile_put_sharded"));
     // Passing the tile array as attributes.
     const auto tile_array = extractTileArray(attributes);
     return lowerTilePutShardedToPoplar(graph, inputs, outputs, tile_array,
@@ -54,12 +55,15 @@ class TilePutShardedPrimitive : public TilePutBase {
                                   poplar::Type type,
                                   const std::string& attributes,
                                   const std::string& debug_prefix) {
+    const auto debug_context = poplar::DebugContext(
+        makeTileOpDebugPrefix(debug_prefix, "tile_put_sharded"));
     const auto tile_array = extractTileArray(attributes);
     const auto item_shape =
         poplar::ArrayRef<std::size_t>(shape.data() + 1, shape.size() - 1);
     // If not allocated => already pre-allocate input with proper tile mapping.
     // TODO: fix (unnecessary) on-tile-copy when doing that?
-    return createShardedVariable(graph, type, item_shape, tile_array);
+    return createShardedVariable(graph, type, item_shape, tile_array,
+                                 debug_context);
   }
 };
 
@@ -83,7 +87,8 @@ class TilePutReplicatedPrimitive : public TilePutBase {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debug_context = poplar::DebugContext(debug_prefix);
+    const auto debug_context = poplar::DebugContext(
+        makeTileOpDebugPrefix(debug_prefix, "tile_put_replicated"));
     const auto tile_array = extractTileArray(attributes);
     return lowerTilePutReplicatedToPoplar(graph, inputs, outputs, tile_array,
                                           debug_context);
@@ -109,7 +114,8 @@ class TileGatherPrimitive : public jax::ipu::PrimitiveInterface {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debug_context = poplar::DebugContext(debug_prefix);
+    const auto debug_context = poplar::DebugContext(
+        makeTileOpDebugPrefix(debug_prefix, "tile_gather"));
     // Tile gather parameters.
     const auto params = ipu::from_json_str<TileGatherParams>(attributes);
     return lowerTileGatherToPoplar(graph, inputs, outputs, params,
@@ -138,7 +144,8 @@ class TileDataBarrierPrimitive : public jax::ipu::PrimitiveInterface {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debug_context = poplar::DebugContext(debug_prefix);
+    const auto debug_context = poplar::DebugContext(
+        makeTileOpDebugPrefix(debug_prefix, "tile_data_barrier"));
     // Tile barrier parameters (with tile sharding).
     const auto params = ipu::from_json_str<TileDataBarrierParams>(attributes);
     return lowerTileDataBarrierToPoplar(graph, inputs, outputs, params,
@@ -165,7 +172,8 @@ class TileConstantReplicatedPrimitive : public jax::ipu::PrimitiveInterface {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debug_context = poplar::DebugContext(debug_prefix);
+    const auto debug_context = poplar::DebugContext(
+        makeTileOpDebugPrefix(debug_prefix, "tile_constant_replicated"));
     const auto params = ipu::from_json_str<TileConstantParams>(attributes);
     return lowerTileConstantReplicatedToPoplar(graph, inputs, outputs, params,
                                                debug_context);
@@ -191,7 +199,8 @@ class TileConstantShardedPrimitive : public jax::ipu::PrimitiveInterface {
       poplar::Graph& graph, const std::vector<poplar::Tensor>& inputs,
       std::vector<poplar::Tensor>& outputs, const std::string& attributes,
       const std::string& debug_prefix) {
-    const auto debug_context = poplar::DebugContext(debug_prefix);
+    const auto debug_context = poplar::DebugContext(
+        makeTileOpDebugPrefix(debug_prefix, "tile_constant_sharded"));
     const auto params = ipu::from_json_str<TileConstantParams>(attributes);
     return lowerTileConstantShardedToPoplar(graph, inputs, outputs, params,
                                             debug_context);

--- a/tessellate_ipu/lib/tile_array_ops.hpp
+++ b/tessellate_ipu/lib/tile_array_ops.hpp
@@ -6,6 +6,14 @@
 #include "base_types.hpp"
 
 namespace ipu {
+
+/**
+ * @brief Make a (readable/clean) tile op debug prefix.
+ * Help having a more readable naming in PopVision profile.
+ */
+std::string makeTileOpDebugPrefix(const std::string& raw_debug_prefix,
+                                  const std::string& basename);
+
 /**
  * @brief IPU tile gather op parameters.
  */

--- a/tessellate_ipu/lib/tile_map_ops.cpp
+++ b/tessellate_ipu/lib/tile_map_ops.cpp
@@ -14,8 +14,6 @@ std::string makeTileMapCallDebugPrefix(const std::string& raw_debug_prefix,
                                        const std::string& primitive_name) {
   const auto format_debug_prefix = [&raw_debug_prefix,
                                     &primitive_name](std::size_t idx) {
-    // const std::string debug_prefix = raw_debug_prefix.substr(0, idx) +
-    // "tile_map";
     const std::string debug_prefix =
         fmt::format("{}{}[{}]", raw_debug_prefix.substr(0, idx), "tile_map",
                     primitive_name);


### PR DESCRIPTION
A couple of improvements on TessellateIPU naming in Popvision profiles:
* Single tensor created in `tile_replicated_...` ops;
* Proper debug context in `tile_put/replicated_...` ops;
* Proper naming of constants in `tile_map`;