### PR TITLE
Use optimized `rotation2d` kernel in Jacobi eigh update first step.

### DIFF
--- a/tessellate_ipu/core/vertex/tile_small_dot.cpp
+++ b/tessellate_ipu/core/vertex/tile_small_dot.cpp
@@ -48,6 +48,7 @@ class [[poplar::constraint("elem(*inrow0) != elem(*outrow0)",
     T2* outrow0_ptr = reinterpret_cast<T2*>(outrow0.data()) + wstart;
     T2* outrow1_ptr = reinterpret_cast<T2*>(outrow1.data()) + wstart;
 
+    // Passing IPU model/hardware tag type.
     rotation2d_f32<IPU_TAG_TYPE>(cs_ptr[0], inrow0_ptr, inrow1_ptr, outrow0_ptr,
                                  outrow1_ptr, wsize);
     return true;

--- a/tests/linalg/test_tile_linalg_jacobi.py
+++ b/tests/linalg/test_tile_linalg_jacobi.py
@@ -100,7 +100,7 @@ class IpuTileLinalgJacobi(chex.TestCase, parameterized.TestCase):
         # assert False
 
     def test__jacobi_update_first_step_vertex__benchmark_performance(self):
-        N = 128
+        N = 256
         tiles = (0,)
         pq = np.array([3, N // 2], dtype=np.uint32)
         pcol = np.random.randn(1, N).astype(np.float32)
@@ -123,7 +123,7 @@ class IpuTileLinalgJacobi(chex.TestCase, parameterized.TestCase):
 
         start, end = np.asarray(start)[0], np.asarray(end)[0]
         qr_correction_cycle_count = end[0] - start[0]
-        assert qr_correction_cycle_count <= 1700
+        assert qr_correction_cycle_count <= 1550
         # print("CYCLE count:", qr_correction_cycle_count)
         # assert False
 


### PR DESCRIPTION
Switching to optimized kernel giving a 2x speedup on the vertex.