### PR TITLE
Optimize Jacobi update second step vertex

### DIFF
--- a/tessellate_ipu/core/vertex/intrinsics_utils.hpp
+++ b/tessellate_ipu/core/vertex/intrinsics_utils.hpp
@@ -64,6 +64,7 @@ ALWAYS_INLINE T ipu_div_by_6(T n) noexcept {
  */
 ALWAYS_INLINE void __builtin_ipu_put_tas(float v) noexcept {
   // TAS register, used for __builtin_ipu_f32v2axpy.
+  // TODO: use `__builtin_ipu_uput`?
   asm volatile(
       R"l( uput $TAS, %[sv]
         )l"
@@ -71,6 +72,20 @@ ALWAYS_INLINE void __builtin_ipu_put_tas(float v) noexcept {
       : [ sv ] "r"(v)
       :);
 }
+
+/**
+ * @brief Zero AACC registers.
+ */
+ALWAYS_INLINE void __builtin_ipu_aacc_zero() {
+  asm (R"(
+    setzi $a0, 0x8
+    uput $FP_CLR, $a0
+  )"
+      :
+      :
+      : "$a0");
+}
+
 
 /**
  * @brief IPU cmac f32 instruction.

--- a/tessellate_ipu/core/vertex/ipu_amp.hpp
+++ b/tessellate_ipu/core/vertex/ipu_amp.hpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+#pragma once
+#include <type_traits>
+
+#include "intrinsics_utils.hpp"
+#include "ipu_model_types.hpp"
+
+namespace ipu {
+
+/**
+ * @brief Thin abstraction of the IPU AMP unit(s) and registers, allowing
+ * to write generic code compiling on IPU model and IPU hardware.
+ *
+ * NOTE: zero-cost abstraction on IPU hardware.
+ *
+ * The AMP class is modelling AACC registers as well as AMP unit instructions
+ * on the IPU model, reproducing the expected behaviour of the hardware.
+ */
+template <typename T>
+class AMP {
+ public:
+  // TODO: support half as well.
+  static_assert(std::is_same_v<T, float>);
+  using FPType = T;
+  /** Number of AACC register available in hw. */
+  // TODO: use TFPU_AMP_UNITS_PER_SET and TFPU_AACC_PER_AMP_UNIT;
+  static constexpr unsigned NumAACC = 16;
+
+  // TODO: random initialization on IPU model of registers.
+  AMP() noexcept = default;
+  // No copy + no move allowed!
+  AMP(const AMP&) = delete;
+  AMP(AMP&&) = delete;
+
+  /**
+   * @brief Set the value of the TAS register, used in
+   * `axpy` operation.
+   */
+  ALWAYS_INLINE void tas(FPType val) noexcept {
+#ifdef __IPU__
+    __builtin_ipu_put_tas(val);
+#else
+    m_tas = val;
+#endif
+  }
+  /**
+   * @brief Zero AACC registers.
+   */
+  ALWAYS_INLINE void aaccZero() noexcept {
+#ifdef __IPU__
+    __builtin_ipu_aacc_zero();
+#else
+    for (unsigned idx = 0; idx < NumAACC; ++idx) {
+      m_aacc[idx] = 0;
+    }
+#endif
+  }
+
+  /**
+   * @brief Scaled-add `axpy` intrinsic. Only supported on FP32.
+   * NOTE: act as 1 stage pipeline, storing result in AACC[0...2]
+   */
+  ALWAYS_INLINE float2 axpy(float2 x, float2 y) noexcept {
+    using T2 = float2;
+#ifdef __IPU__
+    // Weird ordering here? Bug in the intrinsic definition?
+    return __builtin_ipu_f32v2axpy(y, x);
+#else
+    // Simulating pipeline with storing in AACC[0] and AACC[2].
+    const auto res = T2{m_aacc[0], m_aacc[2]};
+    // FIXME/TODO: understand ordering!?
+    m_aacc[0] = m_tas * x[0] + y[0];
+    m_aacc[2] = m_tas * x[1] + y[1];
+    return res;
+#endif
+  }
+
+  /**
+   * @brief Outer-product `aop` intrinsic. Only supported on FP32.
+   * Storing results in AACC[0...6]
+   */
+  void aop(float2 x, float2 y) noexcept {
+#ifdef __IPU__
+    // Note: third argument not used by hw.
+    __builtin_ipu_f32v2aop(x, y, 0);
+#else
+    // Multiply + accumulate.
+    m_aacc[0] += x[0] * y[0];
+    m_aacc[2] += x[1] * y[0];
+    m_aacc[4] += x[0] * y[1];
+    m_aacc[6] += x[1] * y[1];
+#endif
+  }
+
+  /**
+   * @brief `gina` instruction: get AACC register + propagate.
+   * FIXME: support non-zero flag/index.
+   */
+  template <unsigned int FLAG>
+  float2 gina(float2 val) noexcept {
+    using T2 = float2;
+#ifdef __IPU__
+    return __builtin_ipu_f32v2gina(val, 0);
+#else
+    // TODO: implement GINA_IMMFLAGS__SET__GET
+    const auto res = T2{m_aacc[0], m_aacc[2]};
+    // Propagate accumulator states.
+    for (unsigned idx = 4; idx < NumAACC; idx += 4) {
+      m_aacc[idx - 4] = m_aacc[idx];
+      m_aacc[idx - 2] = m_aacc[idx + 2];
+    }
+    m_aacc[NumAACC - 4] = val[0];
+    m_aacc[NumAACC - 2] = val[1];
+    return res;
+#endif
+  }
+
+ private:
+#ifndef __IPU__
+  // Simulating AACC registers on IPU model.
+  FPType m_aacc[NumAACC];
+  // Simulating TAS register on IPU model.
+  FPType m_tas;
+#endif
+};
+
+}  // namespace ipu

--- a/tessellate_ipu/core/vertex/tile_small_dot.hpp
+++ b/tessellate_ipu/core/vertex/tile_small_dot.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2023 Graphcore Ltd. All rights reserved.
 #include "intrinsics_utils.hpp"
+#include "ipu_amp.hpp"
 
 /**
  * @brief z = a*x + b*y float32 implementation.
@@ -35,9 +36,9 @@ inline void axplusby_f32(float a, float b, const float2 *x, const float2 *y,
   // __builtin_assume(nblocks < 4096);
   using T2 = float2;
   const T2 av = {a, a};
-  // Using TAS register for one of the scalar.
-  __ipu_and_ipumodel_tas tas;
-  tas.put(b);
+  // Basic AMP usage with TAS + axpy instruction.
+  ipu::AMP<float> amp;
+  amp.tas(b);
 
   T2 res, xv, yv, zv, tmp;
 
@@ -49,13 +50,11 @@ inline void axplusby_f32(float a, float b, const float2 *x, const float2 *y,
     // popc should be able to generate an optimal rpt loop.
     {
       xv = ipu::load_postinc(&x, 1);
-      // TODO: fix ordering of arguments in `f32v2axpy`.
-      tmp = tas.f32v2axpy(res, yv);
+      tmp = amp.axpy(yv, res);
     }
     {
       yv = ipu::load_postinc(&y, 1);
-      // TODO: fix ordering of arguments in `f32v2axpy`.
-      zv = tas.f32v2axpy(tmp, tmp);
+      zv = amp.axpy(tmp, tmp);
     }
     {
       ipu::store_postinc(&z, zv, 1);
@@ -139,7 +138,8 @@ template <class IpuTag>
 inline void rotation2d_f32(float2 cs, const float2 *inrow0,
                            const float2 *inrow1, float2 *outrow0,
                            float2 *outrow1, rptsize_t nblocks) {
-  // TODO: investigate using IPU AMP unit?
+  // axplusby is using one AMP unit. TODO: investigate using more!
   axplusby_f32<IpuTag>(cs[0], -cs[1], inrow0, inrow1, outrow0, nblocks);
+  // NOTE: inrow1+0, outrow1 arguments order necessary due to bank constraints!
   axplusby_f32<IpuTag>(cs[0], cs[1], inrow1, inrow0, outrow1, nblocks);
 }

--- a/tessellate_ipu/linalg/tile_linalg_jacobi.py
+++ b/tessellate_ipu/linalg/tile_linalg_jacobi.py
@@ -19,6 +19,7 @@ from tessellate_ipu import (
     tile_put_sharded,
 )
 from tessellate_ipu.core.tile_interpreter_vertex_utils import make_ipu_vector1d_worker_offsets
+from tessellate_ipu.lax import tile_fill
 from tessellate_ipu.utils import NDArray
 
 Array = Any
@@ -69,8 +70,10 @@ jacobi_update_second_step_p = create_ipu_tile_primitive(
     inputs=["cs_arr", "rotset_sorted_arr", "rotset_idx_ignored", "pcol", "qcol"],
     outputs={"cs_arr": 0, "pcol_updated": 3, "qcol_updated": 4},
     constants={
+        # NOTE: using grain_size=4 because of partial loop unrolling
+        # TODO: support overlap properly.
         "worker_offsets": lambda inavals, *_: make_ipu_vector1d_worker_offsets(
-            inavals[3].size - INDEX_PREFIX, vector_size=2, wdtype=np.uint16
+            inavals[3].size - INDEX_PREFIX, vector_size=2, wdtype=np.uint16, allow_overlap=False, grain_size=4
         )
     },
     gp_filename=get_jacobi_vertex_gp_filename(),
@@ -232,6 +235,14 @@ def ipu_jacobi_eigh_body(idx: Array, inputs: Tuple[TileShardedArray, ...]) -> Tu
         rotset_sorted_sharded, cs_per_tile, Apcols, Aqcols = tile_map(  # type:ignore
             jacobi_update_first_step_p, Apcols, Aqcols
         )
+        # Append zero indices to the rotset, for loop unrolling in `jacobi_update_second_step`
+        rotset_zeros = tile_fill((2,), 0, dtype=rotset_sorted_sharded.dtype, tiles=(0,))
+        # Barrier to make sure communication gets fused into a single block.
+        rotset_zeros, rotset_sorted_sharded, cs_per_tile = tile_data_barrier(
+            rotset_zeros, rotset_sorted_sharded, cs_per_tile
+        )
+        rotset_sorted_sharded = TileShardedArray.concatenate([rotset_sorted_sharded, rotset_zeros])
+
         # Replicate Schur decomposition + rotset across all A tiles: (2*N//2) comms.
         with jax.named_scope("rotset_sorted_replicated"):
             rotset_sorted_replicated = tile_put_replicated(rotset_sorted_sharded.array, tiles=Atiles)

--- a/tests/linalg/test_tile_linalg_jacobi.py
+++ b/tests/linalg/test_tile_linalg_jacobi.py
@@ -178,7 +178,7 @@ class IpuTileLinalgJacobi(chex.TestCase, parameterized.TestCase):
 
     @unittest.skipUnless(ipu_num_tiles >= 16, "Requires IPU with 16 tiles")
     def test__jacobi_eigh_raw__proper_eigh_result(self):
-        N = 8
+        N = 12
         x = np.random.randn(N, N).astype(np.float32)
         x = (x + x.T) / 2.0
 


### PR DESCRIPTION
The second step of the Jacobi algorithm is an usual "sparse" access
update pattern, which can not be simply optimized with a `rpt` loop.

The loop is intrinsically limited by the number of load/store
operations. Nevertheless, by using `aop` outer product intrinsic +
unrolling of 2 steps, the bundling of operations in the loop can be
massively improved, leading to 40% decrease of cycle count.

Additionally, this PR is adding a thin AMP C++ abstraction, allowing
a simple implementation between IPU hardware and IPU model.