### PR TITLE
Removing links to run on Gradient

### DIFF
--- a/notebooks/IPU Peak Flops.ipynb
+++ b/notebooks/IPU Peak Flops.ipynb
@@ -28,9 +28,7 @@
    "source": [
     "## Environment setup\n",
     "\n",
-    "The best way to run this notebook is on Paperspace Gradient's cloud IPUs because everything is already set up for you.\n",
-    "\n",
-    "To run the demo using other IPU hardware, you need to have the Poplar SDK enabled {and a PopTorch/TensorFlow wheel installed}. Refer to the [Getting Started guide](https://docs.graphcore.ai/en/latest/getting-started.html#getting-started) for your system for details on how to do this. Also refer to the [Jupyter Quick Start guide](https://docs.graphcore.ai/projects/jupyter-notebook-quick-start/en/latest/index.html) for how to set up Jupyter to be able to run this notebook on a remote IPU machine."
+    "To run the demo using IPU hardware, you need to have the Poplar SDK enabled {and a PopTorch/TensorFlow wheel installed}. Refer to the [Getting Started guide](https://docs.graphcore.ai/en/latest/getting-started.html#getting-started) for your system for details on how to do this. Also refer to the [Jupyter Quick Start guide](https://docs.graphcore.ai/projects/jupyter-notebook-quick-start/en/latest/index.html) for how to set up Jupyter to be able to run this notebook on a remote IPU machine."
    ]
   },
   {


### PR DESCRIPTION
IPUs are no longer available on Paperspace. Marketing has asked that the Run on Gradient links be removed from content on GitHub.